### PR TITLE
fix hash typo in cashier and bump version number

### DIFF
--- a/ic3_labels/__about__.py
+++ b/ic3_labels/__about__.py
@@ -1,4 +1,4 @@
-__version__ = '1.0.0-dev'
+__version__ = '1.1.0-dev'
 __author__ = "Mirco Huennefeld"
 __author_email__ = "mirco.huennefeld@tu-dortmund.de"
 __description__ = "Creates MC labels for IceCube simulation data"

--- a/ic3_labels/weights/resources/cashier.py
+++ b/ic3_labels/weights/resources/cashier.py
@@ -115,7 +115,7 @@ def cache(cache_file=".cache", pickle_protocol=3, read_only=True):
                 [kwargs[k] for k in sorted(kwargs.keys())]
             )
             objects_tr = []
-            for o in objects_tr:
+            for o in objects:
                 if isinstance(o, np.ndarray):
                     objects_tr.append(o.tolist())
                 else:


### PR DESCRIPTION
- cashier saved function arguments using a hash, using the hash of an empty list
- fixing this breaks functionality of using old cashes, so the version number is increased to '1.1.0'