### PR TITLE
CompatibilitySimweights

### DIFF
--- a/ic3_labels/labels/utils/general.py
+++ b/ic3_labels/labels/utils/general.py
@@ -127,6 +127,71 @@ def get_num_coincident_events(frame):
     return len(frame['I3MCTree'].get_primaries())
 
 
+def get_weighted_primary(frame, mctree_name=None):
+    """Add weighted primary to frame
+
+    Weighted CORSIKA simulation (as well as some NuGen simulation) can have
+    coincidences mixed in that should not be used to calculate weights, as they
+    were chosen at "natural" frequency. Find the primary that was chosen from a
+    biased spectrum, and put it in the frame.
+
+    Parameters
+    ----------
+    frame : TYPE
+        Description
+    mctree_name : str, optional
+        The name of the I3MCTree to use.
+        If None is provided, one of 'I3MCTree_preMuonProp', 'I3MCTree'
+        will be used.
+
+    Returns
+    -------
+    I3Particle
+        The primary particle
+    """
+
+    if mctree_name is None:
+        for mctree in ['I3MCTree_preMuonProp', 'I3MCTree']:
+            if (mctree in frame) and (len(frame[mctree].primaries) != 0):
+                mctree_name = mctree
+                break
+
+    primaries = frame[mctree_name].primaries
+
+    if len(primaries) == 0:
+        return None
+
+    if len(primaries) == 1:
+        idx = 0
+
+    elif 'I3MCWeightDict' in frame:
+        idx = [i for i in range(len(primaries)) if primaries[i].is_neutrino]
+        assert len(idx) == 0, (idx, primaries)
+        idx = idx[0]
+
+    elif 'CorsikaWeightMap' in frame:
+        wmap = frame['CorsikaWeightMap']
+
+        if len(primaries) == 0:
+            return None
+
+        elif len(primaries) == 1:
+            idx = 0
+
+        elif 'PrimaryEnergy' in wmap:
+            prim_e = wmap['PrimaryEnergy']
+            idx = int(np.nanargmin([abs(p.energy-prim_e) for p in primaries]))
+
+        elif 'PrimarySpectralIndex' in wmap:
+            prim_e = wmap['Weight']**(-1./wmap['PrimarySpectralIndex'])
+            idx = int(np.nanargmin([abs(p.energy-prim_e) for p in primaries]))
+
+        else:
+            idx = 0
+
+    return primaries[idx]
+
+
 def particle_is_inside(particle, convex_hull):
     '''Checks if a particle is inside the convex hull.
     The particle is considered inside if any part of its track is inside

--- a/ic3_labels/labels/utils/general.py
+++ b/ic3_labels/labels/utils/general.py
@@ -128,17 +128,19 @@ def get_num_coincident_events(frame):
 
 
 def get_weighted_primary(frame, mctree_name=None):
-    """Add weighted primary to frame
+    """Return weighted primary from I3MCTree
 
     Weighted CORSIKA simulation (as well as some NuGen simulation) can have
     coincidences mixed in that should not be used to calculate weights, as they
     were chosen at "natural" frequency. Find the primary that was chosen from a
     biased spectrum, and put it in the frame.
 
+    Note: This code is adopted from old icecube.simweights project
+
     Parameters
     ----------
-    frame : TYPE
-        Description
+    frame : I3Frame
+        The I3Frame from which to retrieve the weighted primary particle.
     mctree_name : str, optional
         The name of the I3MCTree to use.
         If None is provided, one of 'I3MCTree_preMuonProp', 'I3MCTree'

--- a/ic3_labels/labels/utils/high_level.py
+++ b/ic3_labels/labels/utils/high_level.py
@@ -1173,14 +1173,22 @@ def get_cascade_labels(frame, primary, convex_hull, extend_boundary=0,
                     muon = m
 
         labels['p_entering'] = 1
-        labels['VertexX'] = entry_max.x
-        labels['VertexY'] = entry_max.y
-        labels['VertexZ'] = entry_max.z
-        labels['VertexTime'] = time_max
+        if entry_max is None:
+            labels['VertexX'] = float('nan')
+            labels['VertexY'] = float('nan')
+            labels['VertexZ'] = float('nan')
+            labels['VertexTime'] = float('nan')
+            labels['Length'] = float('nan')
+            labels['LengthInDetector'] = float('nan')
+        else:
+            labels['VertexX'] = entry_max.x
+            labels['VertexY'] = entry_max.y
+            labels['VertexZ'] = entry_max.z
+            labels['VertexTime'] = time_max
+            labels['Length'] = muon.length
+            labels['LengthInDetector'] = \
+                mu_utils.get_muon_track_length_inside(muon, convex_hull)
         labels['EnergyVisible'] = bundle_info['bundle_energy_at_entry']
-        labels['Length'] = muon.length
-        labels['LengthInDetector'] = \
-            mu_utils.get_muon_track_length_inside(muon, convex_hull)
 
         if bundle_info['num_muons_at_entry_above_threshold'] > 0:
             bundle_key = 'num_muons_at_entry_above_threshold'

--- a/ic3_labels/labels/utils/high_level.py
+++ b/ic3_labels/labels/utils/high_level.py
@@ -1199,14 +1199,16 @@ def get_cascade_labels(frame, primary, convex_hull, extend_boundary=0,
         elif bundle_info['num_muons_at_cyl'] > 0:
             bundle_key = 'num_muons_at_cyl'
         else:
-            raise ValueError('Expected at least one muon!', frame['I3MCTree'])
+            bundle_key = None
+            print('Expected at least one muon!', frame['I3MCTree'])
 
-        if bundle_info[bundle_key] == 1:
-            labels['p_entering_muon_single'] = 1
-            labels['p_entering_muon_single_stopping'] = \
-                mu_utils.is_stopping_muon(muon, convex_hull)
-        else:
-            labels['p_entering_muon_bundle'] = 1
+        if bundle_key is not None:
+            if bundle_info[bundle_key] == 1:
+                labels['p_entering_muon_single'] = 1
+                labels['p_entering_muon_single_stopping'] = \
+                    mu_utils.is_stopping_muon(muon, convex_hull)
+            else:
+                labels['p_entering_muon_bundle'] = 1
 
     # Check if event is track. Definition used here:
     #   Event is track if at least one muon exists in cylinder and the length

--- a/ic3_labels/labels/utils/muon.py
+++ b/ic3_labels/labels/utils/muon.py
@@ -11,6 +11,7 @@ from icecube.icetray.i3logging import log_error, log_warn
 from ic3_labels.labels.utils import geometry
 from ic3_labels.labels.utils.general import get_ids_of_particle_and_daughters
 from ic3_labels.labels.utils.general import particle_is_inside
+from ic3_labels.labels.utils.general import get_weighted_primary
 
 
 def is_muon(particle):
@@ -1569,8 +1570,7 @@ def get_parent_muons(frame, particle=None, mctree_name='I3MCTree'):
 
     # get the primary particle of the I3MCTree if none provided
     if particle is None:
-        particle = general.get_weighted_primary(
-            frame=frame, mctree_name=mctree_name)
+        particle = get_weighted_primary(frame=frame, mctree_name=mctree_name)
 
     muons = []
     # Now walk through each daughter particle recursively

--- a/ic3_labels/labels/utils/muon.py
+++ b/ic3_labels/labels/utils/muon.py
@@ -1569,10 +1569,8 @@ def get_parent_muons(frame, particle=None, mctree_name='I3MCTree'):
 
     # get the primary particle of the I3MCTree if none provided
     if particle is None:
-        primaries = frame[mctree_name].get_primaries()
-        if len(primaries) != 1:
-            raise ValueError('Expected exactly 1 primary, got:', primaries)
-        particle = primaries[0]
+        particle = general.get_weighted_primary(
+            frame=frame, mctree_name=mctree_name)
 
     muons = []
     # Now walk through each daughter particle recursively

--- a/ic3_labels/labels/utils/neutrino.py
+++ b/ic3_labels/labels/utils/neutrino.py
@@ -135,7 +135,7 @@ def get_interaction_neutrino_rec(frame, primary,
     daughters = mctree.get_daughters(primary)
 
     # No daughters found, so no interaction
-    if len(daughters) is 0:
+    if len(daughters) == 0:
         return None
 
     # check if interaction point is inside
@@ -169,7 +169,7 @@ def get_interaction_neutrino_rec(frame, primary,
             if neutrino is not None:
                 interaction_neutrinos.append(neutrino)
 
-        if len(interaction_neutrinos) is 0:
+        if len(interaction_neutrinos) == 0:
             # No neutrinos interacting in the convex hull could be found.
             return None
 

--- a/ic3_labels/weights/fluxes_corsika.py
+++ b/ic3_labels/weights/fluxes_corsika.py
@@ -12,7 +12,12 @@ from ic3_labels.weights.resources import fluxes as _fluxes
 
 class MIMIC_NEUTRINOFLUX():
     def __init__(self, weighting_flux, name, unit_conversion=1.):
-        allowed_base_classes = (fluxes.CompiledFlux, _fluxes.CosmicRayFlux)
+        allowed_base_classes = []
+        if hasattr(fluxes, 'CompiledFlux'):
+            allowed_base_classes.append(fluxes.CompiledFlux)
+        if hasattr(fluxes, 'CosmicRayFlux'):
+            allowed_base_classes.append(fluxes.CosmicRayFlux)
+
         if not isinstance(weighting_flux, allowed_base_classes):
             raise TypeError('Weighting Flux has to be an instance '
                             'of CompiledFlux or CosmicRayFlux!')

--- a/ic3_labels/weights/fluxes_corsika.py
+++ b/ic3_labels/weights/fluxes_corsika.py
@@ -61,8 +61,10 @@ def get_fluxes_and_names(fallback_to_ic3_labels_flux=False):
 
                     # skip over FixedFractionFlux, which requires
                     # additional fractions set
-                    if isinstance(cls, fluxes.FixedFractionFlux):
+                    if issubclass(cls, fluxes.FixedFractionFlux):
                         flux_model = None
+
+                    raise e
 
                 # Fall back to ic3_labels version
                 # (currently necessary for python >=3.8)

--- a/ic3_labels/weights/fluxes_corsika.py
+++ b/ic3_labels/weights/fluxes_corsika.py
@@ -17,6 +17,8 @@ class MIMIC_NEUTRINOFLUX():
             allowed_base_classes.append(fluxes.CompiledFlux)
         if hasattr(fluxes, 'CosmicRayFlux'):
             allowed_base_classes.append(fluxes.CosmicRayFlux)
+        if hasattr(fluxes, '_fluxes'):
+            allowed_base_classes.append(fluxes._fluxes.CosmicRayFlux)
         allowed_base_classes = tuple(allowed_base_classes)
 
         if not isinstance(weighting_flux, allowed_base_classes):

--- a/ic3_labels/weights/fluxes_corsika.py
+++ b/ic3_labels/weights/fluxes_corsika.py
@@ -57,6 +57,13 @@ def get_fluxes_and_names(fallback_to_ic3_labels_flux=False):
                         cls(), obj, unit_conversion=unit_conversion)
                     flux_model.getFlux(1e4, 14, 0.)
 
+                except TypeError as e:
+
+                    # skip over FixedFractionFlux, which requires
+                    # additional fractions set
+                    if isinstance(cls, fluxes.FixedFractionFlux):
+                        continue
+
                 # Fall back to ic3_labels version
                 # (currently necessary for python >=3.8)
                 except Exception as e:

--- a/ic3_labels/weights/fluxes_corsika.py
+++ b/ic3_labels/weights/fluxes_corsika.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-from __future__ import division, print_function
+import numpy as np
 from inspect import isclass
 
 try:

--- a/ic3_labels/weights/fluxes_corsika.py
+++ b/ic3_labels/weights/fluxes_corsika.py
@@ -17,6 +17,7 @@ class MIMIC_NEUTRINOFLUX():
             allowed_base_classes.append(fluxes.CompiledFlux)
         if hasattr(fluxes, 'CosmicRayFlux'):
             allowed_base_classes.append(fluxes.CosmicRayFlux)
+        allowed_base_classes = tuple(allowed_base_classes)
 
         if not isinstance(weighting_flux, allowed_base_classes):
             raise TypeError('Weighting Flux has to be an instance '

--- a/ic3_labels/weights/fluxes_corsika.py
+++ b/ic3_labels/weights/fluxes_corsika.py
@@ -3,13 +3,17 @@
 from __future__ import division, print_function
 from inspect import isclass
 
-from icecube.weighting import fluxes
+try:
+    from icecube.weighting import fluxes
+except ModuleNotFoundError as e:
+    import simweights as fluxes
+
 from icecube.icetray.i3logging import log_error, log_warn
 from ic3_labels.weights.resources import fluxes as _fluxes
 
 
 class MIMIC_NEUTRINOFLUX():
-    def __init__(self, weighting_flux, name):
+    def __init__(self, weighting_flux, name, unit_conversion=1.):
         allowed_base_classes = (fluxes.CompiledFlux, _fluxes.CosmicRayFlux)
         if not isinstance(weighting_flux, allowed_base_classes):
             raise TypeError('Weighting Flux has to be an instance '
@@ -17,25 +21,42 @@ class MIMIC_NEUTRINOFLUX():
         else:
             self.weighting_flux = weighting_flux
             self.name = name
+            self.unit_conversion = unit_conversion
 
     def getFlux(self, ptype, energy, costheta):
-        return self.weighting_flux(energy, ptype)
+        return self.weighting_flux(energy, ptype) * self.unit_conversion
 
     def __str__(self):
         return self.name
 
 
 def get_fluxes_and_names(fallback_to_ic3_labels_flux=False):
+
+    # get parent class
+    try:
+        ParentClass = fluxes.CompiledFlux
+        unit_conversion = 1.
+    except Exception as e:
+        ParentClass = CosmicRayFlux
+        unit_conversion = 0.0001  # cm^2 to m^2
+
+    # cross-check if used fluxes have correct units
+    # note: simweights changed output from m^2 to cm^2 at some point
+    flux = fluxes.Hoerandel()(1e5, 14)
+    flux_ic3labels = _fluxes.Hoerandel()(1e5, 14)
+    assert np.allclose(flux * unit_conversion, flux_ic3labels), (
+        flux, flux_ic3labels, unit_conversion)
+
     flux_models = []
     for obj in dir(fluxes):
         cls = getattr(fluxes, obj)
         if isclass(cls):
-            if issubclass(cls, fluxes.CompiledFlux) and \
-               cls != fluxes.CompiledFlux:
+            if issubclass(cls, ParentClass) and cls != ParentClass:
 
-                # Try to use flux from icecube.weighting.fluxes
+                # Try to use flux from icecube.weighting.fluxes / simweights
                 try:
-                    flux_model = MIMIC_NEUTRINOFLUX(cls(), obj)
+                    flux_model = MIMIC_NEUTRINOFLUX(
+                        cls(), obj, unit_conversion=unit_conversion)
                     flux_model.getFlux(1e4, 14, 0.)
 
                 # Fall back to ic3_labels version
@@ -48,7 +69,8 @@ def get_fluxes_and_names(fallback_to_ic3_labels_flux=False):
                         log_warn('Falling back to ic3_labels flux {}'.format(
                             obj))
                         cls = getattr(_fluxes, obj)
-                        flux_model = MIMIC_NEUTRINOFLUX(cls(), obj)
+                        flux_model = MIMIC_NEUTRINOFLUX(
+                            cls(), obj, unit_conversion=1.)
 
                     # if not falling back on ic3_labels fluxed: raise error
                     else:

--- a/ic3_labels/weights/fluxes_corsika.py
+++ b/ic3_labels/weights/fluxes_corsika.py
@@ -37,7 +37,7 @@ def get_fluxes_and_names(fallback_to_ic3_labels_flux=False):
         ParentClass = fluxes.CompiledFlux
         unit_conversion = 1.
     except Exception as e:
-        ParentClass = CosmicRayFlux
+        ParentClass = fluxes.CosmicRayFlux
         unit_conversion = 0.0001  # cm^2 to m^2
 
     # cross-check if used fluxes have correct units

--- a/ic3_labels/weights/fluxes_corsika.py
+++ b/ic3_labels/weights/fluxes_corsika.py
@@ -21,7 +21,8 @@ class MIMIC_NEUTRINOFLUX():
 
         if not isinstance(weighting_flux, allowed_base_classes):
             raise TypeError('Weighting Flux has to be an instance '
-                            'of CompiledFlux or CosmicRayFlux!')
+                            'of CompiledFlux or CosmicRayFlux!',
+                            weighting_flux)
         else:
             self.weighting_flux = weighting_flux
             self.name = name

--- a/ic3_labels/weights/fluxes_corsika.py
+++ b/ic3_labels/weights/fluxes_corsika.py
@@ -62,7 +62,7 @@ def get_fluxes_and_names(fallback_to_ic3_labels_flux=False):
                     # skip over FixedFractionFlux, which requires
                     # additional fractions set
                     if isinstance(cls, fluxes.FixedFractionFlux):
-                        continue
+                        flux_model = None
 
                 # Fall back to ic3_labels version
                 # (currently necessary for python >=3.8)
@@ -81,7 +81,8 @@ def get_fluxes_and_names(fallback_to_ic3_labels_flux=False):
                     else:
                         raise e
 
-                flux_models.append(flux_model)
+                if flux_model is not None:
+                    flux_models.append(flux_model)
 
     return flux_models, \
         [str(flux_model_i) + 'Weight' for flux_model_i in flux_models]

--- a/ic3_labels/weights/fluxes_corsika.py
+++ b/ic3_labels/weights/fluxes_corsika.py
@@ -37,7 +37,7 @@ def get_fluxes_and_names(fallback_to_ic3_labels_flux=False):
         ParentClass = fluxes.CompiledFlux
         unit_conversion = 1.
     except Exception as e:
-        ParentClass = fluxes.CosmicRayFlux
+        ParentClass = fluxes._fluxes.CosmicRayFlux
         unit_conversion = 0.0001  # cm^2 to m^2
 
     # cross-check if used fluxes have correct units

--- a/ic3_labels/weights/fluxes_corsika.py
+++ b/ic3_labels/weights/fluxes_corsika.py
@@ -63,8 +63,8 @@ def get_fluxes_and_names(fallback_to_ic3_labels_flux=False):
                     # additional fractions set
                     if issubclass(cls, fluxes.FixedFractionFlux):
                         flux_model = None
-
-                    raise e
+                    else:
+                        raise e
 
                 # Fall back to ic3_labels version
                 # (currently necessary for python >=3.8)

--- a/ic3_labels/weights/segments.py
+++ b/ic3_labels/weights/segments.py
@@ -2,8 +2,13 @@
 # -*- coding: utf-8 -*-
 from __future__ import division, print_function
 
-from icecube.weighting.weighting import from_simprod
-from icecube.weighting import get_weighted_primary
+
+try:
+    from icecube.weighting.weighting import from_simprod
+    from icecube.weighting import get_weighted_primary
+except ModuleNotFoundError as e:
+    from ic3_labels.weights.utils import get_weighted_primary
+
 from icecube import icetray, dataclasses
 from icecube import MuonGun
 from icecube.icetray import I3Units

--- a/ic3_labels/weights/segments.py
+++ b/ic3_labels/weights/segments.py
@@ -104,7 +104,7 @@ def calc_weights(frame, fluxes, flux_names, n_files, generator, key):
             type_weight = 1.0
 
             spectral_index = cwm["PrimarySpectralIndex"]
-            if spectral_index == 0:
+            if spectral_index == -1:
                 energy_integral = (
                     np.log(cwm['EnergyPrimaryMax'])
                     - np.log(cwm['EnergyPrimaryMin'])

--- a/ic3_labels/weights/segments.py
+++ b/ic3_labels/weights/segments.py
@@ -103,11 +103,18 @@ def calc_weights(frame, fluxes, flux_names, n_files, generator, key):
             n_events = cwm['NEvents']
             type_weight = 1.0
 
-            energy_integral = (
-                cwm['EnergyPrimaryMax']**(cwm["PrimarySpectralIndex"] + 1)
-                - cwm['EnergyPrimaryMin']**(cwm["PrimarySpectralIndex"] + 1)
-                ) / (cwm["PrimarySpectralIndex"] + 1)
-            energy_weight = cwm['PrimaryEnergy']**cwm["PrimarySpectralIndex"]
+            spectral_index = cwm["PrimarySpectralIndex"]
+            if spectral_index == 0:
+                energy_integral = (
+                    np.log(cwm['EnergyPrimaryMax'])
+                    - np.log(cwm['EnergyPrimaryMin'])
+                )
+            else:
+                energy_integral = (
+                    cwm['EnergyPrimaryMax']**(spectral_index + 1)
+                    - cwm['EnergyPrimaryMin']**(spectral_index + 1)
+                    ) / (spectral_index + 1)
+            energy_weight = cwm['PrimaryEnergy']**spectral_index
             one_weight = energy_integral / energy_weight * cwm["AreaSum"]
 
         elif frame.Has('I3MCWeightDict'):

--- a/ic3_labels/weights/segments.py
+++ b/ic3_labels/weights/segments.py
@@ -13,7 +13,12 @@ from icecube import icetray, dataclasses
 from icecube import MuonGun
 from icecube.icetray import I3Units
 
-from collections import Iterable
+try:
+    from collections import Iterable
+except ImportError:
+    # >= python 3.10
+    from collections.abc import Iterable
+
 from copy import deepcopy
 
 import math

--- a/ic3_labels/weights/segments.py
+++ b/ic3_labels/weights/segments.py
@@ -1,7 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-from __future__ import division, print_function
-
 
 try:
     from icecube.weighting.weighting import from_simprod

--- a/ic3_labels/weights/utils.py
+++ b/ic3_labels/weights/utils.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+from icecube import dataclasses
+
 
 # some enums for CORSIKA->PDG compatibility
 ParticleType = {

--- a/ic3_labels/weights/utils.py
+++ b/ic3_labels/weights/utils.py
@@ -1,0 +1,93 @@
+import numpy as np
+
+
+# some enums for CORSIKA->PDG compatibility
+ParticleType = {
+    'Gamma': 1,
+    'PPlus': 14,
+    'He4Nucleus': 402,
+    'N14Nucleus': 1407,
+    'O16Nucleus': 1608,
+    'Al27Nucleus': 2713,
+    'Fe56Nucleus': 5626,
+    'NuE': 66,
+    'NuEBar': 67,
+    'NuMu': 68,
+    'NuMuBar': 69,
+    'NuTau': 133,
+    'NuTauBar': 134,
+    'MuMinus': 6,
+    'MuPlus': 5,
+}
+
+
+def get_weighted_primary(frame, MCPrimary='MCPrimary'):
+    """Add weighted primary to frame
+
+    Weighted CORSIKA simulation (as well as some NuGen simulation) can have
+    coincidences mixed in that should not be used to calculate weights, as they
+    were chosen at "natural" frequency. Find the primary that was chosen from a
+    biased spectrum, and put it in the frame.
+
+    Parameters
+    ----------
+    frame : TYPE
+        Description
+    MCPrimary : str, optional
+        Name of the primary particle to put into the frame.
+    """
+
+    MCTreeName = None
+    for mctree in ['I3MCTree_preMuonProp', 'I3MCTree']:
+        if (mctree in frame) and (len(frame[mctree].primaries) != 0):
+            MCTreeName = mctree
+            break
+
+    if MCTreeName is None:
+        return
+
+    primaries = frame[MCTreeName].primaries
+
+    if len(primaries) == 0:
+        return
+
+    if len(primaries) == 1:
+        idx = 0
+
+    elif 'I3MCWeightDict' in frame:
+        idx = [i for i in range(len(primaries)) if primaries[i].is_neutrino]
+        assert len(idx) == 0, (idx, primaries)
+        idx = idx[0]
+
+    elif 'CorsikaWeightMap' in frame:
+        wmap = frame['CorsikaWeightMap']
+        # Only filter by particle type if we're still using CORSIKA-style
+        # codes. This is a horrendous hack that will have to be revisited
+        # once PDG-coded simulation becomes more common.
+        if dataclasses.I3Particle.PPlus == ParticleType['PPlus']:
+            if 'PrimaryType' in wmap:
+                primaries = [
+                    p for p in primaries if p.type == wmap['PrimaryType']]
+
+            elif 'ParticleType' in wmap:
+                primaries = [
+                    p for p in primaries if p.type == wmap['ParticleType']]
+
+        if len(primaries) == 0:
+            return
+
+        elif len(primaries) == 1:
+            idx = 0
+
+        elif 'PrimaryEnergy' in wmap:
+            prim_e = wmap['PrimaryEnergy']
+            idx = int(np.nanargmin([abs(p.energy-prim_e) for p in primaries]))
+
+        elif 'PrimarySpectralIndex' in wmap:
+            prim_e = wmap['Weight']**(-1./wmap['PrimarySpectralIndex'])
+            idx = int(np.nanargmin([abs(p.energy-prim_e) for p in primaries]))
+
+        else:
+            idx = 0
+
+    frame[MCPrimary] = primaries[idx]

--- a/ic3_labels/weights/utils.py
+++ b/ic3_labels/weights/utils.py
@@ -35,11 +35,6 @@ def get_weighted_primary(frame, MCPrimary='MCPrimary'):
         Description
     MCPrimary : str, optional
         Name of the primary particle to put into the frame.
-
-    Returns
-    -------
-    I3Particle
-        The weighted primary.
     """
 
     MCTreeName = None
@@ -49,12 +44,12 @@ def get_weighted_primary(frame, MCPrimary='MCPrimary'):
             break
 
     if MCTreeName is None:
-        return None
+        return
 
     primaries = frame[MCTreeName].primaries
 
     if len(primaries) == 0:
-        return None
+        return
 
     if len(primaries) == 1:
         idx = 0
@@ -79,7 +74,7 @@ def get_weighted_primary(frame, MCPrimary='MCPrimary'):
                     p for p in primaries if p.type == wmap['ParticleType']]
 
         if len(primaries) == 0:
-            return None
+            return
 
         elif len(primaries) == 1:
             idx = 0
@@ -96,4 +91,3 @@ def get_weighted_primary(frame, MCPrimary='MCPrimary'):
             idx = 0
 
     frame[MCPrimary] = primaries[idx]
-    return primaries[idx]

--- a/ic3_labels/weights/utils.py
+++ b/ic3_labels/weights/utils.py
@@ -35,6 +35,11 @@ def get_weighted_primary(frame, MCPrimary='MCPrimary'):
         Description
     MCPrimary : str, optional
         Name of the primary particle to put into the frame.
+
+    Returns
+    -------
+    I3Particle
+        The weighted primary.
     """
 
     MCTreeName = None
@@ -44,12 +49,12 @@ def get_weighted_primary(frame, MCPrimary='MCPrimary'):
             break
 
     if MCTreeName is None:
-        return
+        return None
 
     primaries = frame[MCTreeName].primaries
 
     if len(primaries) == 0:
-        return
+        return None
 
     if len(primaries) == 1:
         idx = 0
@@ -74,7 +79,7 @@ def get_weighted_primary(frame, MCPrimary='MCPrimary'):
                     p for p in primaries if p.type == wmap['ParticleType']]
 
         if len(primaries) == 0:
-            return
+            return None
 
         elif len(primaries) == 1:
             idx = 0
@@ -91,3 +96,4 @@ def get_weighted_primary(frame, MCPrimary='MCPrimary'):
             idx = 0
 
     frame[MCPrimary] = primaries[idx]
+    return primaries[idx]

--- a/ic3_labels/weights/utils.py
+++ b/ic3_labels/weights/utils.py
@@ -1,29 +1,7 @@
-import numpy as np
-
-from icecube import dataclasses
+from ic3_labels.labels.utils import general
 
 
-# some enums for CORSIKA->PDG compatibility
-ParticleType = {
-    'Gamma': 1,
-    'PPlus': 14,
-    'He4Nucleus': 402,
-    'N14Nucleus': 1407,
-    'O16Nucleus': 1608,
-    'Al27Nucleus': 2713,
-    'Fe56Nucleus': 5626,
-    'NuE': 66,
-    'NuEBar': 67,
-    'NuMu': 68,
-    'NuMuBar': 69,
-    'NuTau': 133,
-    'NuTauBar': 134,
-    'MuMinus': 6,
-    'MuPlus': 5,
-}
-
-
-def get_weighted_primary(frame, MCPrimary='MCPrimary'):
+def get_weighted_primary(frame, MCPrimary='MCPrimary', mctree_name=None):
     """Add weighted primary to frame
 
     Weighted CORSIKA simulation (as well as some NuGen simulation) can have
@@ -33,63 +11,14 @@ def get_weighted_primary(frame, MCPrimary='MCPrimary'):
 
     Parameters
     ----------
-    frame : TYPE
-        Description
+    frame : I3Frame
+        The I3Frame from which to retrieve the weighted primary particle.
     MCPrimary : str, optional
         Name of the primary particle to put into the frame.
+    mctree_name : str, optional
+        The name of the I3MCTree to use.
+        If None is provided, one of 'I3MCTree_preMuonProp', 'I3MCTree'
+        will be used.
     """
-
-    MCTreeName = None
-    for mctree in ['I3MCTree_preMuonProp', 'I3MCTree']:
-        if (mctree in frame) and (len(frame[mctree].primaries) != 0):
-            MCTreeName = mctree
-            break
-
-    if MCTreeName is None:
-        return
-
-    primaries = frame[MCTreeName].primaries
-
-    if len(primaries) == 0:
-        return
-
-    if len(primaries) == 1:
-        idx = 0
-
-    elif 'I3MCWeightDict' in frame:
-        idx = [i for i in range(len(primaries)) if primaries[i].is_neutrino]
-        assert len(idx) == 0, (idx, primaries)
-        idx = idx[0]
-
-    elif 'CorsikaWeightMap' in frame:
-        wmap = frame['CorsikaWeightMap']
-        # Only filter by particle type if we're still using CORSIKA-style
-        # codes. This is a horrendous hack that will have to be revisited
-        # once PDG-coded simulation becomes more common.
-        if dataclasses.I3Particle.PPlus == ParticleType['PPlus']:
-            if 'PrimaryType' in wmap:
-                primaries = [
-                    p for p in primaries if p.type == wmap['PrimaryType']]
-
-            elif 'ParticleType' in wmap:
-                primaries = [
-                    p for p in primaries if p.type == wmap['ParticleType']]
-
-        if len(primaries) == 0:
-            return
-
-        elif len(primaries) == 1:
-            idx = 0
-
-        elif 'PrimaryEnergy' in wmap:
-            prim_e = wmap['PrimaryEnergy']
-            idx = int(np.nanargmin([abs(p.energy-prim_e) for p in primaries]))
-
-        elif 'PrimarySpectralIndex' in wmap:
-            prim_e = wmap['Weight']**(-1./wmap['PrimarySpectralIndex'])
-            idx = int(np.nanargmin([abs(p.energy-prim_e) for p in primaries]))
-
-        else:
-            idx = 0
-
-    frame[MCPrimary] = primaries[idx]
+    frame[MCPrimary] = general.get_weighted_primary(
+        frame=frame, mctree_name=mctree_name)


### PR DESCRIPTION
Updates code to be compatible for removed `icecube.weighting` in favor of `simweights` package. Changes are backward-compatible and should produce same weights, regardless of which icetray version (with/without  `icecube.weighting`) is used. Adds some minor updates to label computation for `get_cascade_labels` to account for edge cases that previously triggered asserts.