### PR TITLE
Feature/add default convex hulls ludwig

### DIFF
--- a/ic3_labels/labels/base_module.py
+++ b/ic3_labels/labels/base_module.py
@@ -8,9 +8,6 @@ from scipy.spatial import ConvexHull
 
 from ic3_labels.labels.utils import detector
 
-import re
-
-EXTENDED_HULL_RE = re.compile("icecube_hull_ext_([+-]?\d+)")
 
 class MCLabelsBase(icetray.I3ConditionalModule):
 
@@ -68,8 +65,8 @@ class MCLabelsBase(icetray.I3ConditionalModule):
             self._convex_hull = ConvexHull(points)
 
         elif isinstance(self._convex_hull, str):
-            if (match := EXTENDED_HULL_RE.match(self._convex_hull)) is not None:
-                extension = int(match.group(1))
+            if self._convex_hull.startswith("icecube_hull_ext_"):
+                extension = float(self._convex_hull.split("_")[-1])
                 self._convex_hull = detector.get_extended_convex_hull(extension)
             else:
                 self._convex_hull = getattr(detector, self._convex_hull)

--- a/ic3_labels/labels/base_module.py
+++ b/ic3_labels/labels/base_module.py
@@ -27,7 +27,7 @@ class MCLabelsBase(icetray.I3ConditionalModule):
             "The the convex hull to use. Must either be an instance of "
             "scipy.spatial.ConvexHull or a string defining a convex hull "
             "in ic3_labels.labels.utils.detector."
-            "Or a string named icecube_hull_ext_{extensin in meters}."
+            "Or a string named icecube_hull_ext_{extension in meters}."
             "If None is provided, a "
             "convex hull around the outer IceCube strings will be constructed "
             "based on the given Geometry file.",

--- a/ic3_labels/labels/base_module.py
+++ b/ic3_labels/labels/base_module.py
@@ -68,9 +68,9 @@ class MCLabelsBase(icetray.I3ConditionalModule):
             self._convex_hull = ConvexHull(points)
 
         elif isinstance(self._convex_hull, str):
-            if (match := EXTENDED_HULL_RE.matches(self._convex_hull)) is not None:
+            if (match := EXTENDED_HULL_RE.match(self._convex_hull)) is not None:
                 extension = int(match.group(1))
-                self._conex_hull = detector.get_extended_convex_hull(extension)
+                self._convex_hull = detector.get_extended_convex_hull(extension)
             else:
                 self._convex_hull = getattr(detector, self._convex_hull)
 

--- a/ic3_labels/labels/base_module.py
+++ b/ic3_labels/labels/base_module.py
@@ -8,6 +8,9 @@ from scipy.spatial import ConvexHull
 
 from ic3_labels.labels.utils import detector
 
+import re
+
+EXTENDED_HULL_RE = re.compile("icecube_hull_ext_([+-]?\d+)")
 
 class MCLabelsBase(icetray.I3ConditionalModule):
 
@@ -26,7 +29,9 @@ class MCLabelsBase(icetray.I3ConditionalModule):
             "ConvexHull",
             "The the convex hull to use. Must either be an instance of "
             "scipy.spatial.ConvexHull or a string defining a convex hull "
-            "in ic3_labels.labels.utils.detector. If None is provided, a "
+            "in ic3_labels.labels.utils.detector."
+            "Or a string named icecube_hull_ext_{extensin in meters}."
+            "If None is provided, a "
             "convex hull around the outer IceCube strings will be constructed "
             "based on the given Geometry file.",
             None,
@@ -63,7 +68,11 @@ class MCLabelsBase(icetray.I3ConditionalModule):
             self._convex_hull = ConvexHull(points)
 
         elif isinstance(self._convex_hull, str):
-            self._convex_hull = getattr(detector, self._convex_hull)
+            if (match := EXTENDED_HULL_RE.matches(self._convex_hull)) is not None:
+                extension = int(match.group(1))
+                self._conex_hull = detector.get_extended_convex_hull(extension)
+            else:
+                self._convex_hull = getattr(detector, self._convex_hull)
 
         self._dom_pos_dict = domPosDict
         self.PushFrame(frame)

--- a/ic3_labels/labels/utils/detector.py
+++ b/ic3_labels/labels/utils/detector.py
@@ -26,7 +26,11 @@ icecube_hull_points = [
 icecube_hull = ConvexHull(icecube_hull_points)
 
 # add extensions around IceCube
-for extension in [60, 150, 200, 300]:
+def get_extended_convex_hull(extension: float) -> ConvexHull:
+    """
+    Returns the ConvexHull (scipy.spacial.ConvexHull) 
+    of the detector extended by `extension` meters
+    """ 
     icecube_hull_points_i = []
     for x, y, z in icecube_hull_points:
 
@@ -43,8 +47,7 @@ for extension in [60, 150, 200, 300]:
 
         icecube_hull_points_i.append([pos_vec_ext[0], pos_vec_ext[1], z_ext])
 
-    globals()['icecube_hull_ext_{:03}'.format(extension)] = ConvexHull(
-        icecube_hull_points_i)
+    return ConvexHull(icecube_hull_points_i)
 
 # Assuming dust layer to be at -150m to -50m
 icecube_hull_upper = ConvexHull([


### PR DESCRIPTION
This enables to define arbitrary (integer, positive and negative) extended hulls. 
After discussion: might want this to switch to simpler parsing as this is not really readable and does not support floats. Only caveat with 
```python
if self._convex_hull.startswith("icecube_hull_ext_"):
    extension = float(_convex_hull.split("_")[-1])
```
is, that you are then not allowed to define a model named e.g. `icecube_hull_ext_vesion1`.