### PR TITLE
Improve runtime for large I3MCTrees

### DIFF
--- a/ic3_labels/labels/base_module.py
+++ b/ic3_labels/labels/base_module.py
@@ -2,9 +2,7 @@
 '''
 from __future__ import print_function, division
 import numpy as np
-from icecube import dataclasses, icetray
-
-from scipy.spatial import ConvexHull
+from icecube import dataclasses, icetray, phys_services
 
 from ic3_labels.labels.utils import detector
 
@@ -24,9 +22,9 @@ class MCLabelsBase(icetray.I3ConditionalModule):
         self.AddParameter("PrimaryKey", "Name of the primary.", 'MCPrimary')
         self.AddParameter(
             "ConvexHull",
-            "The the convex hull to use. Must either be an instance of "
-            "scipy.spatial.ConvexHull or a string defining a convex hull "
-            "in ic3_labels.labels.utils.detector."
+            "The convex hull to use. Must either be an instance of "
+            "icecube.phys_services.ExtrudedPolygon or a string defining a "
+            "convex hull in ic3_labels.labels.utils.detector."
             "Or a string named icecube_hull_ext_{extension in meters}."
             "If None is provided, a "
             "convex hull around the outer IceCube strings will be constructed "
@@ -62,12 +60,15 @@ class MCLabelsBase(icetray.I3ConditionalModule):
                 domPosDict[(74, 60)], domPosDict[(72, 60)],
                 domPosDict[(78, 60)], domPosDict[(75, 60)]
                 ]
-            self._convex_hull = ConvexHull(points)
+            self._convex_hull = phys_services.ExtrudedPolygon(points)
 
         elif isinstance(self._convex_hull, str):
             if self._convex_hull.startswith("icecube_hull_ext_"):
                 extension = float(self._convex_hull.split("_")[-1])
-                self._convex_hull = detector.get_extended_convex_hull(extension)
+
+                self._convex_hull = phys_services.ExtrudedPolygon(
+                    detector.icecube_hull_points_i3, padding=extension,
+                )
             else:
                 self._convex_hull = getattr(detector, self._convex_hull)
 

--- a/ic3_labels/labels/modules/event_generator/multi_cascade_labels.py
+++ b/ic3_labels/labels/modules/event_generator/multi_cascade_labels.py
@@ -71,6 +71,10 @@ class EventGeneratorMultiCascadeLabels(MCLabelsBase):
         frame : I3Frame
             The frame to which to add the labels.
         """
+
+        # get track_cache
+        track_cache = mu_utils.get_muongun_track_cache(frame)
+
         mc_tree = frame[self._mc_tree_name]
 
         # get cascades: for this synthetic simulation it is assumed
@@ -83,6 +87,7 @@ class EventGeneratorMultiCascadeLabels(MCLabelsBase):
             convex_hull=self._convex_hull,
             extend_boundary=self._extend_boundary,
             write_mc_cascade_to_frame=False,
+            track_cache=track_cache,
         )
         primary_cascade = mc_tree.get_daughters(primary)[0]
 

--- a/ic3_labels/labels/modules/event_generator/multi_cascade_labels.py
+++ b/ic3_labels/labels/modules/event_generator/multi_cascade_labels.py
@@ -73,7 +73,7 @@ class EventGeneratorMultiCascadeLabels(MCLabelsBase):
         """
 
         # get track_cache
-        track_cache = mu_utils.get_muongun_track_cache(frame)
+        track_cache, _ = mu_utils.get_muongun_track_cache(frame)
 
         mc_tree = frame[self._mc_tree_name]
 

--- a/ic3_labels/labels/modules/modules.py
+++ b/ic3_labels/labels/modules/modules.py
@@ -30,13 +30,19 @@ class MCLabelsDeepLearning(MCLabelsBase):
         self._is_muongun = self.GetParameter("IsMuonGun")
 
     def Physics(self, frame):
-        labels = hl.get_labels(frame=frame,
-                               convex_hull=self._convex_hull,
-                               domPosDict=self._dom_pos_dict,
-                               primary=frame[self._primary_key],
-                               pulse_map_string=self._pulse_map_string,
-                               mcpe_series_map_name=self._mcpe_series_map_name,
-                               is_muongun=self._is_muongun)
+        # get track_cache
+        track_cache = mu_utils.get_muongun_track_cache(frame)
+
+        labels = hl.get_labels(
+            frame=frame,
+            convex_hull=self._convex_hull,
+            domPosDict=self._dom_pos_dict,
+            primary=frame[self._primary_key],
+            pulse_map_string=self._pulse_map_string,
+            mcpe_series_map_name=self._mcpe_series_map_name,
+            is_muongun=self._is_muongun,
+            track_cache=track_cache,
+        )
 
         # write to frame
         frame.Put(self._output_key, labels)
@@ -46,9 +52,14 @@ class MCLabelsDeepLearning(MCLabelsBase):
 
 class MCLabelsTau(MCLabelsBase):
     def Physics(self, frame):
+        # get track_cache
+        track_cache = mu_utils.get_muongun_track_cache(frame)
+
         labels = hl.get_tau_labels(
-                    frame=frame,
-                    convex_hull=self._convex_hull)
+            frame=frame,
+            convex_hull=self._convex_hull,
+            track_cache=track_cache,
+        )
 
         # write to frame
         frame.Put(self._output_key, labels)
@@ -58,10 +69,16 @@ class MCLabelsTau(MCLabelsBase):
 
 class MCLabelsCascadeParameters(MCLabelsBase):
     def Physics(self, frame):
-        labels = hl.get_cascade_parameters(frame=frame,
-                                           primary=frame[self._primary_key],
-                                           convex_hull=self._convex_hull,
-                                           extend_boundary=500)
+        # get track_cache
+        track_cache = mu_utils.get_muongun_track_cache(frame)
+
+        labels = hl.get_cascade_parameters(
+            frame=frame,
+            primary=frame[self._primary_key],
+            convex_hull=self._convex_hull,
+            extend_boundary=500,
+            track_cache=track_cache,
+        )
 
         # write to frame
         frame.Put(self._output_key, labels)
@@ -84,10 +101,17 @@ class MCLabelsCascades(MCLabelsBase):
         self._extend_boundary = self.GetParameter("ExtendBoundary")
 
     def Physics(self, frame):
-        labels = hl.get_cascade_labels(frame=frame,
-                                       primary=frame[self._primary_key],
-                                       convex_hull=self._convex_hull,
-                                       extend_boundary=self._extend_boundary)
+
+        # get track_cache
+        track_cache = mu_utils.get_muongun_track_cache(frame)
+
+        labels = hl.get_cascade_labels(
+            frame=frame,
+            primary=frame[self._primary_key],
+            convex_hull=self._convex_hull,
+            extend_boundary=self._extend_boundary,
+            track_cache=track_cache,
+        )
 
         # write to frame
         frame.Put(self._output_key, labels)
@@ -97,8 +121,16 @@ class MCLabelsCascades(MCLabelsBase):
 
 class MCLabelsCorsikaMultiplicity(MCLabelsBase):
     def Physics(self, frame):
-        labels = hl.get_muon_bundle_information(frame=frame,
-                                                convex_hull=self._convex_hull)
+
+        # get track_cache
+        track_cache = mu_utils.get_muongun_track_cache(frame)
+
+        labels = hl.get_muon_bundle_information(
+            frame=frame,
+            convex_hull=self._convex_hull,
+            track_cache=track_cache,
+        )
+
         labels['num_coincident_events'] = \
             general.get_num_coincident_events(frame)
 
@@ -131,6 +163,10 @@ class MCLabelsCorsikaMultiplicity(MCLabelsBase):
 
 class MCLabelsCorsikaAzimuthExcess(MCLabelsBase):
     def Physics(self, frame):
+
+        # get track_cache
+        track_cache = mu_utils.get_muongun_track_cache(frame)
+
         # create empty labelDict
         labels = dataclasses.I3MapStringDouble()
 
@@ -139,8 +175,11 @@ class MCLabelsCorsikaAzimuthExcess(MCLabelsBase):
 
         # get muons
         mostEnergeticMuon = mu_utils.get_most_energetic_muon_inside(
-                                                frame, self._convex_hull,
-                                                muons_inside=muons_inside)
+            frame, self._convex_hull,
+            muons_inside=muons_inside,
+            track_cache=track_cache,
+        )
+
         if mostEnergeticMuon is None:
             labels['Muon_energy'] = np.nan
             labels['Muon_vertexX'] = np.nan
@@ -207,6 +246,10 @@ class MCLabelsMuonScattering(MCLabelsBase):
         self._min_rel_loss_energy = self.GetParameter("MinRelativeLossEnergy")
 
     def Physics(self, frame):
+
+        # get track_cache
+        track_cache = mu_utils.get_muongun_track_cache(frame)
+
         labels = mu_utils.get_muon_scattering_info(
                             frame=frame,
                             primary=frame[self._primary_key],
@@ -216,6 +259,7 @@ class MCLabelsMuonScattering(MCLabelsBase):
                             min_length_after=self._min_length_after,
                             min_muon_entry_energy=self._min_muon_entry_energy,
                             min_rel_loss_energy=self._min_rel_loss_energy,
+                            track_cache=track_cache,
                             )
         frame.Put(self._output_key, labels)
 
@@ -307,11 +351,15 @@ class MCLabelsMuonEnergyLossesInCylinder(MCLabelsBase):
 
     def Physics(self, frame):
 
+        # get track_cache
+        track_cache = mu_utils.get_muongun_track_cache(frame)
+
         # get muon
         muon = mu_utils.get_muon(
             frame=frame,
             primary=frame[self._primary_key],
             convex_hull=self._convex_hull,
+            track_cache=track_cache,
         )
 
         labels = dataclasses.I3MapStringDouble()
@@ -323,6 +371,7 @@ class MCLabelsMuonEnergyLossesInCylinder(MCLabelsBase):
             num_bins=self._num_bins,
             cylinder_height=self._cylinder_height,
             cylinder_radius=self._cylinder_radius,
+            track_cache=track_cache,
           )
 
         # write to frame
@@ -371,11 +420,16 @@ class MCLabelsMuonEnergyLossesMillipede(MCLabelsBase):
         self._max_num_bins = self.GetParameter("MaxNumBins")
 
     def Physics(self, frame):
+
+        # get track_cache
+        track_cache = mu_utils.get_muongun_track_cache(frame)
+
         # get muon
         muon = mu_utils.get_muon(
             frame=frame,
             primary=frame[self._primary_key],
             convex_hull=self._convex_hull,
+            track_cache=track_cache,
         )
 
         labels = dataclasses.I3MapStringDouble()
@@ -387,7 +441,8 @@ class MCLabelsMuonEnergyLossesMillipede(MCLabelsBase):
                         muon=muon,
                         bin_width=self._bin_width,
                         boundary=self._boundary,
-                        return_bin_centers=self._write_vector
+                        return_bin_centers=self._write_vector,
+                        track_cache=track_cache,
                     )
         else:
             binned_energy_losses = mu_utils.get_binned_energy_losses_in_cube(
@@ -395,7 +450,8 @@ class MCLabelsMuonEnergyLossesMillipede(MCLabelsBase):
                 muon=muon,
                 bin_width=self._bin_width,
                 boundary=self._boundary,
-                return_bin_centers=self._write_vector
+                return_bin_centers=self._write_vector,
+                track_cache=track_cache,
             )
 
         # write to frame

--- a/ic3_labels/labels/modules/modules.py
+++ b/ic3_labels/labels/modules/modules.py
@@ -31,7 +31,7 @@ class MCLabelsDeepLearning(MCLabelsBase):
 
     def Physics(self, frame):
         # get track_cache
-        track_cache = mu_utils.get_muongun_track_cache(frame)
+        track_cache, _ = mu_utils.get_muongun_track_cache(frame)
 
         labels = hl.get_labels(
             frame=frame,
@@ -53,7 +53,7 @@ class MCLabelsDeepLearning(MCLabelsBase):
 class MCLabelsTau(MCLabelsBase):
     def Physics(self, frame):
         # get track_cache
-        track_cache = mu_utils.get_muongun_track_cache(frame)
+        track_cache, _ = mu_utils.get_muongun_track_cache(frame)
 
         labels = hl.get_tau_labels(
             frame=frame,
@@ -70,7 +70,7 @@ class MCLabelsTau(MCLabelsBase):
 class MCLabelsCascadeParameters(MCLabelsBase):
     def Physics(self, frame):
         # get track_cache
-        track_cache = mu_utils.get_muongun_track_cache(frame)
+        track_cache, _ = mu_utils.get_muongun_track_cache(frame)
 
         labels = hl.get_cascade_parameters(
             frame=frame,
@@ -103,7 +103,7 @@ class MCLabelsCascades(MCLabelsBase):
     def Physics(self, frame):
 
         # get track_cache
-        track_cache = mu_utils.get_muongun_track_cache(frame)
+        track_cache, _ = mu_utils.get_muongun_track_cache(frame)
 
         labels = hl.get_cascade_labels(
             frame=frame,
@@ -123,7 +123,7 @@ class MCLabelsCorsikaMultiplicity(MCLabelsBase):
     def Physics(self, frame):
 
         # get track_cache
-        track_cache = mu_utils.get_muongun_track_cache(frame)
+        track_cache, _ = mu_utils.get_muongun_track_cache(frame)
 
         labels = hl.get_muon_bundle_information(
             frame=frame,
@@ -165,7 +165,7 @@ class MCLabelsCorsikaAzimuthExcess(MCLabelsBase):
     def Physics(self, frame):
 
         # get track_cache
-        track_cache = mu_utils.get_muongun_track_cache(frame)
+        track_cache, _ = mu_utils.get_muongun_track_cache(frame)
 
         # create empty labelDict
         labels = dataclasses.I3MapStringDouble()
@@ -248,7 +248,7 @@ class MCLabelsMuonScattering(MCLabelsBase):
     def Physics(self, frame):
 
         # get track_cache
-        track_cache = mu_utils.get_muongun_track_cache(frame)
+        track_cache, _ = mu_utils.get_muongun_track_cache(frame)
 
         labels = mu_utils.get_muon_scattering_info(
                             frame=frame,
@@ -352,7 +352,7 @@ class MCLabelsMuonEnergyLossesInCylinder(MCLabelsBase):
     def Physics(self, frame):
 
         # get track_cache
-        track_cache = mu_utils.get_muongun_track_cache(frame)
+        track_cache, _ = mu_utils.get_muongun_track_cache(frame)
 
         # get muon
         muon = mu_utils.get_muon(
@@ -422,7 +422,7 @@ class MCLabelsMuonEnergyLossesMillipede(MCLabelsBase):
     def Physics(self, frame):
 
         # get track_cache
-        track_cache = mu_utils.get_muongun_track_cache(frame)
+        track_cache, _ = mu_utils.get_muongun_track_cache(frame)
 
         # get muon
         muon = mu_utils.get_muon(

--- a/ic3_labels/labels/utils/cascade.py
+++ b/ic3_labels/labels/utils/cascade.py
@@ -336,10 +336,7 @@ def get_cascade_energy_deposited(frame, convex_hull, cascade):
     energy : float
         Deposited Energy.
     '''
-    if geometry.point_is_inside(
-            convex_hull,
-            (cascade.pos.x, cascade.pos.y, cascade.pos.z)
-            ):
+    if geometry.point_is_inside(convex_hull, cascade.pos):
         # if inside convex hull: add all of the energy
         return convert_to_em_equivalent(cascade)
     else:
@@ -416,10 +413,8 @@ def get_cascade_of_primary_nu(frame, primary,
         point_inside = geometry.is_in_detector_bounds(
                             daughters[0].pos, extend_boundary=extend_boundary)
     else:
-        point_inside = geometry.point_is_inside(convex_hull,
-                                                (daughters[0].pos.x,
-                                                 daughters[0].pos.y,
-                                                 daughters[0].pos.z))
+        point_inside = geometry.point_is_inside(convex_hull, daughters[0].pos)
+
     assert point_inside, 'Expected interaction to be inside defined volume!'
     # -----------------------
 

--- a/ic3_labels/labels/utils/detector.py
+++ b/ic3_labels/labels/utils/detector.py
@@ -2,8 +2,67 @@
 """
 from scipy.spatial import ConvexHull
 import numpy as np
+import logging
+
+try:
+    from icecube import dataclasses
+    from icecube import phys_services
+
+    ICETRAY_SUPPORT = True
+
+except ImportError as e:
+    logging.warn(
+        f"Could not import icetray: {e}. "
+        "Continuing without ExtrudedPolygon support."
+    )
+    ICETRAY_SUPPORT = False
 
 
+# add extensions around IceCube
+def get_extended_convex_hull(extension: float) -> ConvexHull:
+    """
+    Returns the ConvexHull (scipy.spacial.ConvexHull)
+    of the detector extended by `extension` meters
+    """
+    icecube_hull_points_i = []
+    for x, y, z in icecube_hull_points:
+
+        # extend along z-axis
+        if z < 0:
+            z_ext = z - extension
+        else:
+            z_ext = z + extension
+
+        # extend radially outward
+        # Note: this is a decent approximation to a proper extended ConvexHull
+        pos_vec = np.array([x, y])
+        pos_vec_ext = pos_vec + extension * pos_vec / np.linalg.norm(pos_vec)
+
+        icecube_hull_points_i.append([pos_vec_ext[0], pos_vec_ext[1], z_ext])
+
+    return ConvexHull(icecube_hull_points_i)
+
+
+def convert_pos_list(points):
+    """Convert an array like list of points to list of I3Position
+
+    Parameters
+    ----------
+    points : array_like
+        Points (x, y, z) given as array .
+        Shape: [n_points, 3]
+
+    Returns
+    -------
+    list[I3Position]
+        A list of I3Position.
+    """
+    return [dataclasses.I3Position(*point) for point in points]
+
+
+# --------------------------------------------------
+# Define some useful sets of points for convex hulls
+# --------------------------------------------------
 icecube_hull_points = [
     [-570.90002441, -125.13999939, -500],  # string 31
     [-256.14001465, -521.08001709, -500],  # string 1
@@ -23,34 +82,9 @@ icecube_hull_points = [
     [-347.88000488,  451.51998901, 500],  # string 75
     [-570.90002441, -125.13999939, 500],  # string 31
 ]
-icecube_hull = ConvexHull(icecube_hull_points)
-
-# add extensions around IceCube
-def get_extended_convex_hull(extension: float) -> ConvexHull:
-    """
-    Returns the ConvexHull (scipy.spacial.ConvexHull) 
-    of the detector extended by `extension` meters
-    """ 
-    icecube_hull_points_i = []
-    for x, y, z in icecube_hull_points:
-
-        # extend along z-axis
-        if z < 0:
-            z_ext = z - extension
-        else:
-            z_ext = z + extension
-
-        # extend radially outward
-        # Note: this is a decent approximation to a proper extended ConvexHull
-        pos_vec = np.array([x, y])
-        pos_vec_ext = pos_vec + extension * pos_vec / np.linalg.norm(pos_vec)
-
-        icecube_hull_points_i.append([pos_vec_ext[0], pos_vec_ext[1], z_ext])
-
-    return ConvexHull(icecube_hull_points_i)
 
 # Assuming dust layer to be at -150m to -50m
-icecube_hull_upper = ConvexHull([
+icecube_hull_upper_points = [
     [-570.90002441, -125.13999939, -50],  # string 31
     [-256.14001465, -521.08001709, -50],  # string 1
     [ 361.        , -422.82998657, -50],  # string 6
@@ -68,9 +102,9 @@ icecube_hull_upper = ConvexHull([
     [  22.11000061,  509.5       , 500],  # string 78
     [-347.88000488,  451.51998901, 500],  # string 75
     [-570.90002441, -125.13999939, 500],  # string 31
-])
+]
 
-icecube_hull_lower = ConvexHull([
+icecube_hull_lower_points = [
     [-570.90002441, -125.13999939, -500],  # string 31
     [-256.14001465, -521.08001709, -500],  # string 1
     [ 361.        , -422.82998657, -500],  # string 6
@@ -88,10 +122,10 @@ icecube_hull_lower = ConvexHull([
     [  22.11000061,  509.5       , -150],  # string 78
     [-347.88000488,  451.51998901, -150],  # string 75
     [-570.90002441, -125.13999939, -150],  # string 31
-])
+]
 
 # This is is convex hull around IceCube minus 1 outer layer and 3 in z
-icecube_veto_hull_m1 = ConvexHull([
+icecube_veto_hull_m1_points = [
     [-447.74, -113.13, -450],  # string 32, DOM 57 (approx z)
     [-211.35, -404.48, -450],  # string 8, DOM 57 (approx z)
     [ 282.18, -325.74, -450],  # string 12, DOM 57 (approx z)
@@ -108,10 +142,10 @@ icecube_veto_hull_m1 = ConvexHull([
     [ -21.97,  393.24, 450],  # string 71, DOM 4 (approx z)
     [-268.9 ,  354.24, 450],  # string 69, DOM 4 (approx z)
     [-447.74, -113.13, 450],  # string 32, DOM 4 (approx z)
-])
+]
 
 # This is is convex hull around IceCube minus 2 outer layers and 6 in z
-icecube_veto_hull_m2 = ConvexHull([
+icecube_veto_hull_m2_points = [
     [-324.39,  -93.43, -400],  # string 33, DOM 54 (approx z)
     [-166.4 , -287.79, -400],  # string 16, DOM 54 (approx z)
     [ 210.47, -209.77, -400],  # string 19, DOM 54 (approx z)
@@ -126,4 +160,25 @@ icecube_veto_hull_m2 = ConvexHull([
     [ 174.47,  315.54, 400],  # string 65, DOM 7 (approx z)
     [-189.98,  257.42, 400],  # string 62, DOM 7 (approx z)
     [-324.39,  -93.43, 400],  # string 33, DOM 7 (approx z)
-])
+]
+
+# -------------------
+# Create convex hulls
+# -------------------
+if ICETRAY_SUPPORT:
+
+    icecube_hull_points_i3 = convert_pos_list(icecube_hull_points)
+
+    icecube_hull = phys_services.ExtrudedPolygon(icecube_hull_points_i3)
+    icecube_hull_upper = phys_services.ExtrudedPolygon(
+        convert_pos_list(icecube_hull_upper_points)
+    )
+    icecube_hull_lower = phys_services.ExtrudedPolygon(
+        convert_pos_list(icecube_hull_lower_points)
+    )
+    icecube_veto_hull_m1 = phys_services.ExtrudedPolygon(
+        convert_pos_list(icecube_veto_hull_m1_points)
+    )
+    icecube_veto_hull_m2 = phys_services.ExtrudedPolygon(
+        convert_pos_list(icecube_veto_hull_m2_points)
+    )

--- a/ic3_labels/labels/utils/general.py
+++ b/ic3_labels/labels/utils/general.py
@@ -201,6 +201,7 @@ def get_weighted_primary(frame, mctree_name=None):
 
 def particle_is_inside(particle, convex_hull):
     '''Checks if a particle is inside the convex hull.
+
     The particle is considered inside if any part of its track is inside
     the convex hull. In the case of point like particles with length zero,
     the particle will be considered to be inside if the vertex is inside
@@ -218,13 +219,12 @@ def particle_is_inside(particle, convex_hull):
     bool
         True if particle is inside, otherwise False.
     '''
-    v_pos = (particle.pos.x, particle.pos.y, particle.pos.z)
-    v_dir = (particle.dir.x, particle.dir.y, particle.dir.z)
-    intersection_ts = geometry.get_intersections(convex_hull, v_pos, v_dir)
+    intersection_ts = geometry.get_intersections(
+        convex_hull, particle.pos, particle.dir)
 
     # particle didn't hit convex_hull
     if intersection_ts.size == 0:
-        return None
+        return False
 
     # particle hit convex_hull:
     #   Expecting two intersections

--- a/ic3_labels/labels/utils/geometry.py
+++ b/ic3_labels/labels/utils/geometry.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*
 '''Helper functions for geometry calculations.
 '''
@@ -6,112 +5,35 @@ from __future__ import print_function, division
 import numpy as np
 import logging
 
+from icecube import dataclasses
+from icecube.phys_services import ExtrudedPolygon
 
-def ray_triangle_intersection(ray_near, ray_dir, triangle):
-    """
-    Möller–Trumbore intersection algorithm in pure python
-    Based on http://en.wikipedia.org/wiki/
-    M%C3%B6ller%E2%80%93Trumbore_intersection_algorithm
-
-    The returned t's are the scaling for ray_dir do get the triangle
-    intersection point. The ray is starting from ray_near and goes to
-    infinity. Only positive t's are returned.
-
-    Parameters
-    ----------
-    ray_near : array-like shape=(3,)
-        Starting point of the ray.
-
-    ray_dir : array-like shape=(3,)
-        Directional vector of the ray.
-
-    triangle : array-like shape=(3, 3)
-        Triangle for which the interaction point should be found.
-
-    Returns
-    -------
-    t : float or np.nan
-        Intersection is ray_near + t * ray_dir or np.nan for no
-        intersection
-
-    """
-    (v1, v2, v3) = triangle
-    eps = 0.000001
-    edge1 = v2 - v1
-    edge2 = v3 - v1
-    pvec = np.cross(ray_dir, edge2)
-    det = edge1.dot(pvec)
-    if abs(det) < eps:
-        return np.nan
-    inv_det = 1. / det
-    tvec = ray_near - v1
-    u = tvec.dot(pvec) * inv_det
-    if u < 0. or u > 1.:
-        return np.nan
-    qvec = np.cross(tvec, edge1)
-    v = ray_dir.dot(qvec) * inv_det
-    if v < 0. or u + v > 1.:
-        return np.nan
-    t = edge2.dot(qvec) * inv_det
-    if t < eps:
-        return np.nan
-    return t
+from ic3_labels.labels.utils import detector
+from ic3_labels.labels.utils.geometry_scipy import (
+    get_axial_cylinder_intersections,
+    get_cube_intersections,
+    distance_to_axis_aligned_Volume,
+    distance_to_icecube_hull,
+    distance_to_deepcore_hull,
+)
 
 
-def remove_similar_intersections(t_s, eps=1e-4):
-    """Remove similar intersections
+def get_intersections(convex_hull, pos, direction):
+    '''Get intersections with convex hull
 
-    Parameters
-    ----------
-    t_s : array_like
-        Scaling factors for v_dir to get the intersection points.
-        Actual intersection points are v_pos + t * v_dir.
-    eps : float or None
-        Min distance between intersection points to be treated as
-        different points.
-
-    Returns
-    -------
-    array_like
-        Selected scaling factors for v_dir to get the intersection points.
-        Actual intersection points are v_pos + t * v_dir.
-    """
-    if isinstance(eps, float) and len(t_s) > 2:
-        if eps >= 0.:
-            t_selected = []
-            for t_i in t_s:
-                distances = [t_i - t_j for t_j in t_selected]
-                if not (np.array(distances) < eps).any():
-                    t_selected.append(t_i)
-
-            if not len(t_selected) in (0, 2):
-                msg = 'Expected 0 or 2 intersections: {}. eps: {} t_s: {}'
-                logging.warning(msg.format(t_selected, eps, t_s))
-
-            t_s = np.array(t_selected)
-    return t_s
-
-
-def get_intersections(convex_hull, v_pos, v_dir, eps=1e-4):
-    '''Function to get the intersection points of an infinite line and the
+    Function to get the intersection points of an infinite line and the
     convex hull. The returned t's are the scaling factors for v_dir to
     get the intersection points. If t < 0 the intersection is 'behind'
     v_pos. This can be used decide whether a track is a starting track.
 
     Parameters
     ----------
-    convex_hull : scipy.spatial.ConvexHull
-        defining the desired convex volume
-
-    v_pos : array-like shape=(3,)
+    convex_hull : icecube.phys_services.ExtrudedPolygon
+        Defines the desired convex volume.
+    pos : I3Position
         A point of the line.
-
-    v_dir : array-like shape=(3,)
+    direction : I3Direction
         Directional vector of the line.
-
-    eps : float or None
-        Min distance between intersection points to be treated as
-        different points.
 
     Returns
     -------
@@ -119,156 +41,13 @@ def get_intersections(convex_hull, v_pos, v_dir, eps=1e-4):
         Scaling factors for v_dir to get the intersection points.
         Actual intersection points are v_pos + t * v_dir.
     '''
-    if not isinstance(v_pos, np.ndarray):
-        v_pos = np.array(v_pos)
-    if not isinstance(v_dir, np.ndarray):
-        v_dir = np.array(v_dir)
-    t_s = [ray_triangle_intersection(v_pos,
-                                     v_dir,
-                                     convex_hull.points[simp])
-           for simp in convex_hull.simplices]
-    t_s = np.array(t_s)
-    t_s = t_s[np.isfinite(t_s)]
-    if len(t_s) != 2:   # A line should have at max 2 intersection points
-                        # with a convex hull
-        t_s_back = [ray_triangle_intersection(v_pos,
-                                              -v_dir,
-                                              convex_hull.points[simp])
-                    for simp in convex_hull.simplices]
-        t_s_back = np.array(t_s_back)
-        t_s_back = t_s_back[np.isfinite(t_s_back)]
-        t_s = np.hstack((t_s, t_s_back * (-1.)))
-
-    # Remove similar intersections
-    t_s = remove_similar_intersections(t_s, eps)
-
-    return t_s
+    res = polygon.intersection(pos, direction)
+    return np.array([t for t in (res.first, res.second) if np.isfinite(t)])
 
 
-def get_axial_cylinder_intersections(
-        v_pos, v_dir, height=1000., radius=600., tol=1e-4):
-    '''Get intersection of infitite track with axial (along z) cylinder
+def point_is_inside(convex_hull, pos):
+    '''Determine if a point is inside the convex hull.
 
-    The returned t's are the scaling factors for v_dir to
-    get the intersection points. If t < 0 the intersection is 'behind'
-    v_pos. This can be used decide whether a track is a starting track.
-
-    Parameters
-    ----------
-    v_pos : array-like
-        A point of the line.
-        Shape: [3]
-    v_dir : array-like
-        Directional vector of the line.
-        Shape: [3]
-    height : float, optional
-        Height of the cylinder.
-        The cylinder is aligned to the z-axis and centered at (0, 0, 0).
-    radius : float, optional
-        Radius of the cylinder.
-        The cylinder is aligned to the z-axis and centered at (0, 0, 0).
-    tol : float, optional
-        Tolerance on computed intersection points.
-
-    Returns
-    -------
-    t : array-like
-        Sorted scaling factors for v_dir to get the intersection points.
-        Actual intersection points are v_pos + t * v_dir.
-        Shape: [n_intersections] (0 or 2)
-    '''
-
-    x, y, z = v_pos
-    dx, dy, dz = v_dir
-
-    c_z = height / 2.
-    r2 = (radius + tol)**2
-
-    # distances to points with sqrt(x**2 + y**2) == r**2
-    # solution for |dz| != 1:
-    # t = -x**2*dy**2 + 2*x*y*dx*dy - y**2*dx**2 + (dx**2 + dy**2)*r**2
-    # l = +- (sqrt(t) - x*dx - y*dy) / (dx**2 + dy**2)
-    t1 = dx**2 + dy**2
-    t2 = -x**2*dy**2 + 2*x*y*dx*dy - y**2*dx**2 + t1*radius**2
-    t_p = (np.sqrt(t2) - x*dx - y*dy) / t1
-    t_n = (-np.sqrt(t2) - x*dx - y*dy) / t1
-
-    # distances to points with z == +- cylinder_ext
-    t_t = (c_z - z) / dz
-    t_b = (-c_z - z) / dz
-
-    # only accept points that are on the edge of the cylinder (plus tol)
-    intersections = []
-    for t_i in [t_p, t_n]:
-        if np.isfinite(t_i) and np.abs(z + t_i * dz) < c_z + tol:
-            intersections.append(t_i)
-
-    for t_i in [t_t, t_b]:
-        if np.isfinite(t_i) and (x + t_i * dx)**2 + (y + t_i * dy)**2 < r2:
-            intersections.append(t_i)
-
-    # Remove similar intersections
-    intersections = remove_similar_intersections(t_s=intersections, eps=tol)
-
-    return np.sort(intersections)
-
-
-def get_cube_intersections(v_pos, v_dir, boundary=600, eps=1e-5):
-    '''Get intersection of infitite track with a zero-centered cube
-    and half edge length of boundary
-
-    The returned t's are the scaling factors for v_dir to
-    get the intersection points. If t < 0 the intersection is 'behind'
-    v_pos. This can be used decide whether a track is a starting track.
-
-    Parameters
-    ----------
-    v_pos : array-like
-        A point of the line.
-        Shape: [3]
-    v_dir : array-like
-        Directional vector of the line.
-        Shape: [3]
-    boundary : float, optional
-        Half edge length of the cube.
-        The cube is centered at (0, 0, 0).
-    eps : float, optional
-        Tolerance level which is applied to check whether a position is
-        within the cube. This tolerance is necessary due to limited precision.
-
-    Returns
-    -------
-    t : array-like
-        Sorted scaling factors for v_dir to get the intersection points.
-        Actual intersection points are v_pos + t * v_dir.
-        Shape: [n_intersections] (0 or 2)
-    '''
-    x, y, z = v_pos
-    dx, dy, dz = v_dir
-
-    v_pos = np.asarray(v_pos)
-    v_dir = np.asarray(v_dir)
-
-    plane_intersection_min = (-boundary - v_pos) / v_dir
-    plane_intersection_max = (boundary - v_pos) / v_dir
-
-    ts = np.append(plane_intersection_min, plane_intersection_max)
-
-    intersections = []
-    for t in ts:
-        # Check if the point is actually inside before adding it
-        if np.any(np.abs(v_pos + t * v_dir) > (boundary + eps)):
-            continue
-        else:
-            intersections.append(t)
-    return np.sort(intersections)
-
-
-def point_is_inside(convex_hull,
-                    v_pos,
-                    default_v_dir=np.array([0., 0., 1.]),
-                    eps=1e-4):
-    '''Function to determine if a point is inside the convex hull.
     A default directional vector is asumend. If this track has an intersection
     in front and behind v_pos, then must v_pos be inside the hull.
     The rare case of a point inside the hull surface is treated as
@@ -276,17 +55,10 @@ def point_is_inside(convex_hull,
 
     Parameters
     ----------
-    convex_hull : scipy.spatial.ConvexHull
-        defining the desired convex volume
-
-    v_pos : array-like shape=(3,)
-        Position.
-
-    default_v_dir : array-like shape=(3,), optional (default=[0, 0, 1])
-        See get_intersections()
-
-    eps : float or None
-        See get_intersections()
+    convex_hull : icecube.phys_services.ExtrudedPolygon
+        Defines the convex hull.
+    pos : I3Position
+        The point for which to check if it's inside the convex hull.
 
     Returns
     -------
@@ -294,21 +66,23 @@ def point_is_inside(convex_hull,
         True if the point is inside the detector.
         False if the point is outside the detector
     '''
-    t_s = get_intersections(convex_hull, v_pos, default_v_dir, eps)
+    t_s = get_intersections(
+        convex_hull=convex_hull,
+        pos=pos,
+        direction=dataclasses.I3Direction(0., 0., 1.),
+    )
     return len(t_s) == 2 and (t_s >= 0).any() and (t_s <= 0).any()
 
 
-def distance_to_convex_hull(convex_hull, v_pos):
-    '''Function to determine the closest distance of a point
-            to the convex hull.
+def distance_to_convex_hull(convex_hull, pos):
+    '''Determine closest distance of a point to the convex hull.
 
     Parameters
     ----------
-    convex_hull : scipy.spatial.ConvexHull
-        defining the desired convex volume
-
-    v_pos : array-like shape=(3,)
-        Position.
+    convex_hull : icecube.phys_services.ExtrudedPolygon
+        Defines the convex hull.
+    pos : I3Position
+        The point for which to check the distance to the convex hull.
 
     Returns
     -------
@@ -322,286 +96,26 @@ def distance_to_convex_hull(convex_hull, v_pos):
     raise NotImplementedError
 
 
-def get_closest_point_on_edge(edge_point1, edge_point2, point):
-    '''Function to determine the closest point
-            on an edge defined by the two points
-            edge_point1 and edge_point2
-
-    Parameters
-    ----------
-
-    edge_point1 : array-like shape=(3,)
-        First edge point .
-
-    edge_point2 : array-like shape=(3,)
-        Second edge point .
-
-    point : array-like shape=(3,)
-        point of which to find the distance
-        to the edge
-
-    Returns
-    -------
-    distance: array-like shape=(3,)
-        closest point on the edge
-    '''
-    if edge_point1 == edge_point2:
-        return ValueError('Points do not define line.')
-    A = np.array(edge_point1)
-    B = np.array(edge_point2)
-    P = np.array(point)
-    vec_edge = B - A
-    vec_point = P - A
-    norm_edge = np.linalg.norm(vec_edge)
-    t_projection = np.dot(vec_edge, vec_point) / (norm_edge**2)
-
-    t_clipped = min(1, max(t_projection, 0))
-    closest_point = A + t_clipped*vec_edge
-
-    return closest_point
-
-
-def get_distance_to_edge(edge_point1, edge_point2, point):
-    '''Function to determine the closest distance of a point
-            to an edge defined by the two points
-            edge_point1 and edge_point2
-
-    Parameters
-    ----------
-
-    edge_point1 : array-like shape=(3,)
-        First edge point .
-
-    edge_point2 : array-like shape=(3,)
-        Second edge point .
-
-    point : array-like shape=(3,)
-        point of which to find the distance
-        to the edge
-
-    Returns
-    -------
-    distance: float
-    '''
-    closest_point = get_closest_point_on_edge(edge_point1,
-                                              edge_point2, point)
-    distance = np.linalg.norm(closest_point - point)
-    return distance
-
-
-def get_edge_intersection(edge_point1, edge_point2, point):
-    '''Returns t:
-        edge_point1 + u*(edge_point2-edge_point1)
-        =
-        point + t * (0, 1, 0)
-        if u is within [0,1].
-        [Helper Function to find out if point
-         is inside the icecube 2D Polygon]
-
-    Parameters
-    ----------
-
-    edge_point1 : array-like shape=(3,)
-        First edge point .
-
-    edge_point2 : array-like shape=(3,)
-        Second edge point .
-
-    point : array-like shape=(3,)
-        point of which to find the distance
-        to the edge
-
-    Returns
-    -------
-    t: float.
-        If intersection is within edge
-        othwise returns nan.
-    '''
-    if edge_point1 == edge_point2:
-        return ValueError('Points do not define line.')
-    A = np.array(edge_point1)
-    B = np.array(edge_point2)
-    P = np.array(point)
-    vec_edge = B - A
-    vec_point = P - A
-
-    u = vec_point[0] / vec_edge[0]
-    t = u * vec_edge[1] - vec_point[1]
-
-    if u > -1e-8 and u < 1 + 1e-8:
-        return t
-    return float('nan')
-
-
-def distance_to_axis_aligned_Volume(pos, points, z_min, z_max):
-    '''Function to determine the closest distance of a point
-       to the edge of a Volume defined by z_zmin,z_max and a
-       2D-Polygon described through a List of counterclockwise
-       points.
-
-    Parameters
-    ----------
-
-    pos :I3Position
-        Position.
-    points : array-like shape=(?,3)
-        List of counterclockwise points
-        describing the polygon of the volume
-        in the x-y-plane
-    z_max : float
-        Top layer of IceCube-Doms
-    z_min : float
-        Bottom layer of IceCube-Doms
-
-    Returns
-    -------
-    distance: float
-        closest distance from the point
-        to the edge of the volume
-        negativ if point is inside,
-        positiv if point is outside
-    '''
-    no_of_points = len(points)
-    edges = [(points[i], points[(i + 1) % (no_of_points)])
-             for i in range(no_of_points)]
-    xy_distance = float('inf')
-    list_of_ts = []
-
-    for edge in edges:
-        x = (edge[0][0], edge[1][0])
-        y = (edge[0][1], edge[1][1])
-        distance = get_distance_to_edge(edge[0], edge[1],
-                                        [pos[0], pos[1], 0])
-        t = get_edge_intersection(edge[0], edge[1],
-                                  [pos[0], pos[1], 0])
-        if not np.isnan(t):
-            list_of_ts.append(t)
-        if distance < xy_distance:
-            xy_distance = distance
-    is_inside_xy = False
-    if len(list_of_ts) == 2:
-        # u's are pos and negativ
-        if list_of_ts[0]*list_of_ts[1] < 0:
-            is_inside_xy = True
-        # point is exactly on border
-        elif len([t for t in list_of_ts if t == 0]) == 1:
-            is_inside_xy = True
-
-    # ---- Calculate z_distance
-    is_inside_z = False
-    if pos[2] < z_min:
-        # underneath detector
-        z_distance = z_min - pos[2]
-    elif pos[2] < z_max:
-        # same height
-        is_inside_z = True
-        z_distance = min(pos[2] - z_min, z_max - pos[2])
-    else:
-        # above detector
-        z_distance = pos[2] - z_max
-
-    # ---- Combine distances
-    if is_inside_z:
-        if is_inside_xy:
-            # inside detector
-            distance = - min(xy_distance, z_distance)
-        else:
-            distance = xy_distance
-    else:
-        if is_inside_xy:
-            distance = z_distance
-        else:
-            distance = np.sqrt(z_distance**2 + xy_distance**2)
-
-    return distance
-
-
-def distance_to_icecube_hull(pos, z_min=-502, z_max=501):
-    '''Function to determine the closest distance of a point
-            to the icecube hull. This is only
-            an approximate distance.
-
-    Parameters
-    ----------
-
-    pos :I3Position
-        Position.
-    z_max : float
-        Top layer of IceCube-Doms
-    z_min : float
-        Bottom layer of IceCube-Doms
-
-    Returns
-    -------
-    distance: float
-        closest distance from the point
-        to the icecube hull
-        negativ if point is inside,
-        positiv if point is outside
-    '''
-    points = [
-           [-570.90002441, -125.13999939, 0],  # string 31
-           [-256.14001465, -521.08001709, 0],  # string 1
-           [ 361.        , -422.82998657, 0],  # string 6
-           [ 576.36999512,  170.91999817, 0],  # string 50
-           [ 338.44000244,  463.72000122, 0],  # string 74
-           [ 101.04000092,  412.79000854, 0],  # string 72
-           [  22.11000061,  509.5       , 0],  # string 78
-           [-347.88000488,  451.51998901, 0],  # string 75
-            ]
-    return distance_to_axis_aligned_Volume(pos, points, z_min, z_max)
-
-
-def distance_to_deepcore_hull(pos, z_min=-502, z_max=188):
-    '''Function to determine the closest distance of a point
-            to the deep core hull. This is only
-            an approximate distance.
-
-    Parameters
-    ----------
-
-    pos :I3Position
-        Position.
-    z_max : float
-        Top layer of IceCube-Doms
-    z_min : float
-        Bottom layer of IceCube-Doms
-
-    Returns
-    -------
-    distance: float
-        closest distance from the point
-        to the icecube hull
-        negativ if point is inside,
-        positiv if point is outside
-    '''
-    points = [
-           [-77.80000305175781, -54.33000183105469, 0],  # string 35
-           [1.7100000381469727, -150.6300048828125, 0],  # string 26
-           [124.97000122070312, -131.25, 0],  # string 27
-           [194.33999633789062, -30.920000076293945, 0],  # string 37
-           [90.48999786376953, 82.3499984741211, 0],  # string 46
-           [-32.959999084472656, 62.439998626708984, 0],  # string 45
-            ]
-    return distance_to_axis_aligned_Volume(pos, points, z_min, z_max)
-
-
 def is_in_detector_bounds(pos, extend_boundary=60):
-    '''Function to determine whether a point is still
-        withtin detector bounds
+    '''Determine whether a point is withtin detector bounds
 
     Parameters
     ----------
     pos : I3Position
         Position to be checked.
-
     extend_boundary : float
         Extend boundary of detector by extend_boundary
 
     Returns
     -------
-    is_inside : bool
+    bool
         True if within detector bounds + extend_boundary
     '''
-    distance = distance_to_icecube_hull(pos)
-    return distance <= extend_boundary
+    convex_hull = ExtrudedPolygon(
+        detector.icecube_hull_points_i3,
+        padding=extend_boundary,
+    )
+    return point_is_inside(
+        convex_hull=convex_hull,
+        pos=pos,
+    )

--- a/ic3_labels/labels/utils/geometry.py
+++ b/ic3_labels/labels/utils/geometry.py
@@ -41,7 +41,7 @@ def get_intersections(convex_hull, pos, direction):
         Scaling factors for v_dir to get the intersection points.
         Actual intersection points are v_pos + t * v_dir.
     '''
-    res = polygon.intersection(pos, direction)
+    res = convex_hull.intersection(pos, direction)
     return np.array([t for t in (res.first, res.second) if np.isfinite(t)])
 
 

--- a/ic3_labels/labels/utils/geometry_scipy.py
+++ b/ic3_labels/labels/utils/geometry_scipy.py
@@ -1,0 +1,606 @@
+# -*- coding: utf-8 -*
+'''Helper functions for geometry calculations.
+'''
+from __future__ import print_function, division
+import numpy as np
+import logging
+
+
+def ray_triangle_intersection(ray_near, ray_dir, triangle):
+    """
+    Möller–Trumbore intersection algorithm in pure python
+    Based on http://en.wikipedia.org/wiki/
+    M%C3%B6ller%E2%80%93Trumbore_intersection_algorithm
+
+    The returned t's are the scaling for ray_dir do get the triangle
+    intersection point. The ray is starting from ray_near and goes to
+    infinity. Only positive t's are returned.
+
+    Parameters
+    ----------
+    ray_near : array-like shape=(3,)
+        Starting point of the ray.
+
+    ray_dir : array-like shape=(3,)
+        Directional vector of the ray.
+
+    triangle : array-like shape=(3, 3)
+        Triangle for which the interaction point should be found.
+
+    Returns
+    -------
+    t : float or np.nan
+        Intersection is ray_near + t * ray_dir or np.nan for no
+        intersection
+
+    """
+    (v1, v2, v3) = triangle
+    eps = 0.000001
+    edge1 = v2 - v1
+    edge2 = v3 - v1
+    pvec = np.cross(ray_dir, edge2)
+    det = edge1.dot(pvec)
+    if abs(det) < eps:
+        return np.nan
+    inv_det = 1. / det
+    tvec = ray_near - v1
+    u = tvec.dot(pvec) * inv_det
+    if u < 0. or u > 1.:
+        return np.nan
+    qvec = np.cross(tvec, edge1)
+    v = ray_dir.dot(qvec) * inv_det
+    if v < 0. or u + v > 1.:
+        return np.nan
+    t = edge2.dot(qvec) * inv_det
+    if t < eps:
+        return np.nan
+    return t
+
+
+def remove_similar_intersections(t_s, eps=1e-4):
+    """Remove similar intersections
+
+    Parameters
+    ----------
+    t_s : array_like
+        Scaling factors for v_dir to get the intersection points.
+        Actual intersection points are v_pos + t * v_dir.
+    eps : float or None
+        Min distance between intersection points to be treated as
+        different points.
+
+    Returns
+    -------
+    array_like
+        Selected scaling factors for v_dir to get the intersection points.
+        Actual intersection points are v_pos + t * v_dir.
+    """
+    if isinstance(eps, float) and len(t_s) > 2:
+        if eps >= 0.:
+            t_selected = []
+            for t_i in t_s:
+                distances = [t_i - t_j for t_j in t_selected]
+                if not (np.array(distances) < eps).any():
+                    t_selected.append(t_i)
+
+            if not len(t_selected) in (0, 2):
+                msg = 'Expected 0 or 2 intersections: {}. eps: {} t_s: {}'
+                logging.warning(msg.format(t_selected, eps, t_s))
+
+            t_s = np.array(t_selected)
+    return t_s
+
+
+def get_intersections(convex_hull, v_pos, v_dir, eps=1e-4):
+    '''Function to get the intersection points of an infinite line and the
+    convex hull. The returned t's are the scaling factors for v_dir to
+    get the intersection points. If t < 0 the intersection is 'behind'
+    v_pos. This can be used decide whether a track is a starting track.
+
+    Parameters
+    ----------
+    convex_hull : scipy.spatial.ConvexHull
+        defining the desired convex volume
+
+    v_pos : array-like shape=(3,)
+        A point of the line.
+
+    v_dir : array-like shape=(3,)
+        Directional vector of the line.
+
+    eps : float or None
+        Min distance between intersection points to be treated as
+        different points.
+
+    Returns
+    -------
+    t : array-like shape=(n_intersections)
+        Scaling factors for v_dir to get the intersection points.
+        Actual intersection points are v_pos + t * v_dir.
+    '''
+    if not isinstance(v_pos, np.ndarray):
+        v_pos = np.array(v_pos)
+    if not isinstance(v_dir, np.ndarray):
+        v_dir = np.array(v_dir)
+    t_s = [ray_triangle_intersection(v_pos,
+                                     v_dir,
+                                     convex_hull.points[simp])
+           for simp in convex_hull.simplices]
+    t_s = np.array(t_s)
+    t_s = t_s[np.isfinite(t_s)]
+    if len(t_s) != 2:   # A line should have at max 2 intersection points
+                        # with a convex hull
+        t_s_back = [ray_triangle_intersection(v_pos,
+                                              -v_dir,
+                                              convex_hull.points[simp])
+                    for simp in convex_hull.simplices]
+        t_s_back = np.array(t_s_back)
+        t_s_back = t_s_back[np.isfinite(t_s_back)]
+        t_s = np.hstack((t_s, t_s_back * (-1.)))
+
+    # Remove similar intersections
+    t_s = remove_similar_intersections(t_s, eps)
+
+    return t_s
+
+
+def get_axial_cylinder_intersections(
+        v_pos, v_dir, height=1000., radius=600., tol=1e-4):
+    '''Get intersection of infitite track with axial (along z) cylinder
+
+    The returned t's are the scaling factors for v_dir to
+    get the intersection points. If t < 0 the intersection is 'behind'
+    v_pos. This can be used decide whether a track is a starting track.
+
+    Parameters
+    ----------
+    v_pos : array-like
+        A point of the line.
+        Shape: [3]
+    v_dir : array-like
+        Directional vector of the line.
+        Shape: [3]
+    height : float, optional
+        Height of the cylinder.
+        The cylinder is aligned to the z-axis and centered at (0, 0, 0).
+    radius : float, optional
+        Radius of the cylinder.
+        The cylinder is aligned to the z-axis and centered at (0, 0, 0).
+    tol : float, optional
+        Tolerance on computed intersection points.
+
+    Returns
+    -------
+    t : array-like
+        Sorted scaling factors for v_dir to get the intersection points.
+        Actual intersection points are v_pos + t * v_dir.
+        Shape: [n_intersections] (0 or 2)
+    '''
+
+    x, y, z = v_pos
+    dx, dy, dz = v_dir
+
+    c_z = height / 2.
+    r2 = (radius + tol)**2
+
+    # distances to points with sqrt(x**2 + y**2) == r**2
+    # solution for |dz| != 1:
+    # t = -x**2*dy**2 + 2*x*y*dx*dy - y**2*dx**2 + (dx**2 + dy**2)*r**2
+    # l = +- (sqrt(t) - x*dx - y*dy) / (dx**2 + dy**2)
+    t1 = dx**2 + dy**2
+    t2 = -x**2*dy**2 + 2*x*y*dx*dy - y**2*dx**2 + t1*radius**2
+    t_p = (np.sqrt(t2) - x*dx - y*dy) / t1
+    t_n = (-np.sqrt(t2) - x*dx - y*dy) / t1
+
+    # distances to points with z == +- cylinder_ext
+    t_t = (c_z - z) / dz
+    t_b = (-c_z - z) / dz
+
+    # only accept points that are on the edge of the cylinder (plus tol)
+    intersections = []
+    for t_i in [t_p, t_n]:
+        if np.isfinite(t_i) and np.abs(z + t_i * dz) < c_z + tol:
+            intersections.append(t_i)
+
+    for t_i in [t_t, t_b]:
+        if np.isfinite(t_i) and (x + t_i * dx)**2 + (y + t_i * dy)**2 < r2:
+            intersections.append(t_i)
+
+    # Remove similar intersections
+    intersections = remove_similar_intersections(t_s=intersections, eps=tol)
+
+    return np.sort(intersections)
+
+
+def get_cube_intersections(v_pos, v_dir, boundary=600, eps=1e-5):
+    '''Get intersection of infitite track with a zero-centered cube
+    and half edge length of boundary
+
+    The returned t's are the scaling factors for v_dir to
+    get the intersection points. If t < 0 the intersection is 'behind'
+    v_pos. This can be used decide whether a track is a starting track.
+
+    Parameters
+    ----------
+    v_pos : array-like
+        A point of the line.
+        Shape: [3]
+    v_dir : array-like
+        Directional vector of the line.
+        Shape: [3]
+    boundary : float, optional
+        Half edge length of the cube.
+        The cube is centered at (0, 0, 0).
+    eps : float, optional
+        Tolerance level which is applied to check whether a position is
+        within the cube. This tolerance is necessary due to limited precision.
+
+    Returns
+    -------
+    t : array-like
+        Sorted scaling factors for v_dir to get the intersection points.
+        Actual intersection points are v_pos + t * v_dir.
+        Shape: [n_intersections] (0 or 2)
+    '''
+    x, y, z = v_pos
+    dx, dy, dz = v_dir
+
+    v_pos = np.asarray(v_pos)
+    v_dir = np.asarray(v_dir)
+
+    plane_intersection_min = (-boundary - v_pos) / v_dir
+    plane_intersection_max = (boundary - v_pos) / v_dir
+
+    ts = np.append(plane_intersection_min, plane_intersection_max)
+
+    intersections = []
+    for t in ts:
+        # Check if the point is actually inside before adding it
+        if np.any(np.abs(v_pos + t * v_dir) > (boundary + eps)):
+            continue
+        else:
+            intersections.append(t)
+    return np.sort(intersections)
+
+
+def point_is_inside(convex_hull,
+                    v_pos,
+                    default_v_dir=np.array([0., 0., 1.]),
+                    eps=1e-4):
+    '''Function to determine if a point is inside the convex hull.
+    A default directional vector is asumend. If this track has an intersection
+    in front and behind v_pos, then must v_pos be inside the hull.
+    The rare case of a point inside the hull surface is treated as
+    being inside the hull.
+
+    Parameters
+    ----------
+    convex_hull : scipy.spatial.ConvexHull
+        defining the desired convex volume
+
+    v_pos : array-like shape=(3,)
+        Position.
+
+    default_v_dir : array-like shape=(3,), optional (default=[0, 0, 1])
+        See get_intersections()
+
+    eps : float or None
+        See get_intersections()
+
+    Returns
+    -------
+    is_inside : boolean
+        True if the point is inside the detector.
+        False if the point is outside the detector
+    '''
+    t_s = get_intersections(convex_hull, v_pos, default_v_dir, eps)
+    return len(t_s) == 2 and (t_s >= 0).any() and (t_s <= 0).any()
+
+
+def distance_to_convex_hull(convex_hull, v_pos):
+    '''Function to determine the closest distance of a point
+            to the convex hull.
+
+    Parameters
+    ----------
+    convex_hull : scipy.spatial.ConvexHull
+        defining the desired convex volume
+
+    v_pos : array-like shape=(3,)
+        Position.
+
+    Returns
+    -------
+    distance: float
+        absolute value of closest distance from the point
+        to the convex hull
+        (maybe easier/better to have distance poositive
+         or negativ depending on wheter the point is inside
+         or outside. Alernatively check with point_is_inside)
+    '''
+    raise NotImplementedError
+
+
+def get_closest_point_on_edge(edge_point1, edge_point2, point):
+    '''Function to determine the closest point
+            on an edge defined by the two points
+            edge_point1 and edge_point2
+
+    Parameters
+    ----------
+
+    edge_point1 : array-like shape=(3,)
+        First edge point .
+
+    edge_point2 : array-like shape=(3,)
+        Second edge point .
+
+    point : array-like shape=(3,)
+        point of which to find the distance
+        to the edge
+
+    Returns
+    -------
+    distance: array-like shape=(3,)
+        closest point on the edge
+    '''
+    if edge_point1 == edge_point2:
+        return ValueError('Points do not define line.')
+    A = np.array(edge_point1)
+    B = np.array(edge_point2)
+    P = np.array(point)
+    vec_edge = B - A
+    vec_point = P - A
+    norm_edge = np.linalg.norm(vec_edge)
+    t_projection = np.dot(vec_edge, vec_point) / (norm_edge**2)
+
+    t_clipped = min(1, max(t_projection, 0))
+    closest_point = A + t_clipped*vec_edge
+
+    return closest_point
+
+
+def get_distance_to_edge(edge_point1, edge_point2, point):
+    '''Function to determine the closest distance of a point
+            to an edge defined by the two points
+            edge_point1 and edge_point2
+
+    Parameters
+    ----------
+
+    edge_point1 : array-like shape=(3,)
+        First edge point .
+
+    edge_point2 : array-like shape=(3,)
+        Second edge point .
+
+    point : array-like shape=(3,)
+        point of which to find the distance
+        to the edge
+
+    Returns
+    -------
+    distance: float
+    '''
+    closest_point = get_closest_point_on_edge(edge_point1,
+                                              edge_point2, point)
+    distance = np.linalg.norm(closest_point - point)
+    return distance
+
+
+def get_edge_intersection(edge_point1, edge_point2, point):
+    '''Returns t:
+        edge_point1 + u*(edge_point2-edge_point1)
+        =
+        point + t * (0, 1, 0)
+        if u is within [0,1].
+        [Helper Function to find out if point
+         is inside the icecube 2D Polygon]
+
+    Parameters
+    ----------
+
+    edge_point1 : array-like shape=(3,)
+        First edge point .
+
+    edge_point2 : array-like shape=(3,)
+        Second edge point .
+
+    point : array-like shape=(3,)
+        point of which to find the distance
+        to the edge
+
+    Returns
+    -------
+    t: float.
+        If intersection is within edge
+        othwise returns nan.
+    '''
+    if edge_point1 == edge_point2:
+        return ValueError('Points do not define line.')
+    A = np.array(edge_point1)
+    B = np.array(edge_point2)
+    P = np.array(point)
+    vec_edge = B - A
+    vec_point = P - A
+
+    u = vec_point[0] / vec_edge[0]
+    t = u * vec_edge[1] - vec_point[1]
+
+    if u > -1e-8 and u < 1 + 1e-8:
+        return t
+    return float('nan')
+
+
+def distance_to_axis_aligned_Volume(pos, points, z_min, z_max):
+    '''Function to determine the closest distance of a point
+       to the edge of a Volume defined by z_zmin,z_max and a
+       2D-Polygon described through a List of counterclockwise
+       points.
+
+    Parameters
+    ----------
+
+    pos :I3Position
+        Position.
+    points : array-like shape=(?,3)
+        List of counterclockwise points
+        describing the polygon of the volume
+        in the x-y-plane
+    z_max : float
+        Top layer of IceCube-Doms
+    z_min : float
+        Bottom layer of IceCube-Doms
+
+    Returns
+    -------
+    distance: float
+        closest distance from the point
+        to the edge of the volume
+        negativ if point is inside,
+        positiv if point is outside
+    '''
+    no_of_points = len(points)
+    edges = [(points[i], points[(i + 1) % (no_of_points)])
+             for i in range(no_of_points)]
+    xy_distance = float('inf')
+    list_of_ts = []
+
+    for edge in edges:
+        x = (edge[0][0], edge[1][0])
+        y = (edge[0][1], edge[1][1])
+        distance = get_distance_to_edge(edge[0], edge[1],
+                                        [pos[0], pos[1], 0])
+        t = get_edge_intersection(edge[0], edge[1],
+                                  [pos[0], pos[1], 0])
+        if not np.isnan(t):
+            list_of_ts.append(t)
+        if distance < xy_distance:
+            xy_distance = distance
+    is_inside_xy = False
+    if len(list_of_ts) == 2:
+        # u's are pos and negativ
+        if list_of_ts[0]*list_of_ts[1] < 0:
+            is_inside_xy = True
+        # point is exactly on border
+        elif len([t for t in list_of_ts if t == 0]) == 1:
+            is_inside_xy = True
+
+    # ---- Calculate z_distance
+    is_inside_z = False
+    if pos[2] < z_min:
+        # underneath detector
+        z_distance = z_min - pos[2]
+    elif pos[2] < z_max:
+        # same height
+        is_inside_z = True
+        z_distance = min(pos[2] - z_min, z_max - pos[2])
+    else:
+        # above detector
+        z_distance = pos[2] - z_max
+
+    # ---- Combine distances
+    if is_inside_z:
+        if is_inside_xy:
+            # inside detector
+            distance = - min(xy_distance, z_distance)
+        else:
+            distance = xy_distance
+    else:
+        if is_inside_xy:
+            distance = z_distance
+        else:
+            distance = np.sqrt(z_distance**2 + xy_distance**2)
+
+    return distance
+
+
+def distance_to_icecube_hull(pos, z_min=-502, z_max=501):
+    '''Function to determine the closest distance of a point
+            to the icecube hull. This is only
+            an approximate distance.
+
+    Parameters
+    ----------
+
+    pos :I3Position
+        Position.
+    z_max : float
+        Top layer of IceCube-Doms
+    z_min : float
+        Bottom layer of IceCube-Doms
+
+    Returns
+    -------
+    distance: float
+        closest distance from the point
+        to the icecube hull
+        negativ if point is inside,
+        positiv if point is outside
+    '''
+    points = [
+           [-570.90002441, -125.13999939, 0],  # string 31
+           [-256.14001465, -521.08001709, 0],  # string 1
+           [ 361.        , -422.82998657, 0],  # string 6
+           [ 576.36999512,  170.91999817, 0],  # string 50
+           [ 338.44000244,  463.72000122, 0],  # string 74
+           [ 101.04000092,  412.79000854, 0],  # string 72
+           [  22.11000061,  509.5       , 0],  # string 78
+           [-347.88000488,  451.51998901, 0],  # string 75
+            ]
+    return distance_to_axis_aligned_Volume(pos, points, z_min, z_max)
+
+
+def distance_to_deepcore_hull(pos, z_min=-502, z_max=188):
+    '''Function to determine the closest distance of a point
+            to the deep core hull. This is only
+            an approximate distance.
+
+    Parameters
+    ----------
+
+    pos :I3Position
+        Position.
+    z_max : float
+        Top layer of IceCube-Doms
+    z_min : float
+        Bottom layer of IceCube-Doms
+
+    Returns
+    -------
+    distance: float
+        closest distance from the point
+        to the icecube hull
+        negativ if point is inside,
+        positiv if point is outside
+    '''
+    points = [
+           [-77.80000305175781, -54.33000183105469, 0],  # string 35
+           [1.7100000381469727, -150.6300048828125, 0],  # string 26
+           [124.97000122070312, -131.25, 0],  # string 27
+           [194.33999633789062, -30.920000076293945, 0],  # string 37
+           [90.48999786376953, 82.3499984741211, 0],  # string 46
+           [-32.959999084472656, 62.439998626708984, 0],  # string 45
+            ]
+    return distance_to_axis_aligned_Volume(pos, points, z_min, z_max)
+
+
+def is_in_detector_bounds(pos, extend_boundary=60):
+    '''Function to determine whether a point is still
+        withtin detector bounds
+
+    Parameters
+    ----------
+    pos : I3Position
+        Position to be checked.
+
+    extend_boundary : float
+        Extend boundary of detector by extend_boundary
+
+    Returns
+    -------
+    is_inside : bool
+        True if within detector bounds + extend_boundary
+    '''
+    distance = distance_to_icecube_hull(pos)
+    return distance <= extend_boundary

--- a/ic3_labels/labels/utils/high_level.py
+++ b/ic3_labels/labels/utils/high_level.py
@@ -103,8 +103,7 @@ def get_total_deposited_energy(frame,
 
         if convex_hull is not None:
             # use convex hull to determine if inside detector
-            if not geometry.point_is_inside(convex_hull,
-                                            (p.pos.x, p.pos.y, p.pos.z)):
+            if not geometry.point_is_inside(convex_hull, p.pos):
                 continue
 
         if extend_boundary is not None:

--- a/ic3_labels/labels/utils/high_level.py
+++ b/ic3_labels/labels/utils/high_level.py
@@ -97,8 +97,9 @@ def get_total_deposited_energy(frame,
 
         # use a basic cylinder to determine if particle was inside
         if cylinder_ext is not None:
-            if (np.abs(p.pos.z) > 500 + cylinder_ext or
-                    np.sqrt(p.pos.x**2 + p.pos.y**2) > 500 + cylinder_ext):
+            dist = 500 + cylinder_ext
+            if (p.pos.z > dist or p.pos.z < -dist or
+                    p.pos.x**2 + p.pos.y**2 > dist**2):
                 continue
 
         if convex_hull is not None:

--- a/ic3_labels/labels/utils/muon.py
+++ b/ic3_labels/labels/utils/muon.py
@@ -1022,17 +1022,16 @@ def get_muon_convex_hull_intersections(track, convex_hull):
     array_like
         The two intersections points
     """
-    v_pos = (track.pos.x, track.pos.y, track.pos.z)
-    v_dir = (track.dir.x, track.dir.y, track.dir.z)
-    intersection_ts = geometry.get_intersections(convex_hull, v_pos, v_dir)
+    intersection_ts = geometry.get_intersections(
+        convex_hull, track.pos, track.dir)
 
     if len(intersection_ts) == 1:
         # vertex is possible exactly on edge of convex hull
         # move vertex slightly by eps
         eps = 1e-4
         muon_pos_shifted = track.pos + eps * track.dir
-        v_pos = (muon_pos_shifted.x, muon_pos_shifted.y, muon_pos_shifted.z)
-        intersection_ts = geometry.get_intersections(convex_hull, v_pos, v_dir)
+        intersection_ts = geometry.get_intersections(
+            convex_hull, muon_pos_shifted, track.dir)
 
     # track hit convex_hull:
     #   Expecting zero or two intersections
@@ -1286,8 +1285,7 @@ def is_mmc_particle_inside(mmc_particle, convex_hull):
 
 
 def is_muon_inside(muon, convex_hull):
-    ''' Find out if muon is insice volume
-        defined by the convex hull
+    '''Find out if muon is inside volume defined by the convex hull
 
     Parameters
     ----------
@@ -1304,8 +1302,7 @@ def is_muon_inside(muon, convex_hull):
     if not is_muon(muon):
         raise ValueError('Particle:\n{}\nis not a muon.'.format(muon))
 
-    return particle_is_inside(particle=muon,
-                              convex_hull=convex_hull)
+    return particle_is_inside(particle=muon, convex_hull=convex_hull)
 
 
 def get_mmc_particles_inside(frame, convex_hull):

--- a/ic3_labels/labels/utils/neutrino.py
+++ b/ic3_labels/labels/utils/neutrino.py
@@ -70,10 +70,10 @@ def get_interaction_neutrino(frame, primary,
                                 daughters[0].pos,
                                 extend_boundary=extend_boundary)
         else:
-            point_inside = geometry.point_is_inside(convex_hull,
-                                                    (daughters[0].pos.x,
-                                                     daughters[0].pos.y,
-                                                     daughters[0].pos.z))
+            point_inside = geometry.point_is_inside(
+                convex_hull, daughters[0].pos,
+            )
+
         if not point_inside:
             nu_in_ice = None
 
@@ -143,10 +143,7 @@ def get_interaction_neutrino_rec(frame, primary,
         point_inside = geometry.is_in_detector_bounds(
                             daughters[0].pos, extend_boundary=extend_boundary)
     else:
-        point_inside = geometry.point_is_inside(convex_hull,
-                                                (daughters[0].pos.x,
-                                                 daughters[0].pos.y,
-                                                 daughters[0].pos.z))
+        point_inside = geometry.point_is_inside(convex_hull, daughters[0].pos)
 
     if point_inside:
         # interaction is inside the convex hull: neutrino found!

--- a/ic3_labels/labels/utils/tau.py
+++ b/ic3_labels/labels/utils/tau.py
@@ -71,9 +71,7 @@ def get_tau_energy_deposited(
     '''
     if tau is None or first_cascade is None or second_cascade is None:
         return np.nan
-    v_pos = (tau.pos.x, tau.pos.y, tau.pos.z)
-    v_dir = (tau.dir.x, tau.dir.y, tau.dir.z)
-    intersection_ts = geometry.get_intersections(convex_hull, v_pos, v_dir)
+    intersection_ts = geometry.get_intersections(convex_hull, tau.pos, tau.dir)
 
     # tau didn't hit convex_hull
     if intersection_ts.size == 0:


### PR DESCRIPTION
This PR improves the runtime for the calculation of common labels for large I3MCTrees such as in high-energy CORSIKA simulations. The runtime improvement is driven by two changes:

- The default convex hull construction is now based on `phys-services::ExtrudedPolygon` instead of the previous implementation in python. Moving this to c++ provided a considerable speedup for these functions around 2-3 orders of magnitude. As far as I can tell, there is currently no equivalent options for the `distance_to_icecube/deepcore` functions. If necessary these functions should be fairly easy to port to c++ via pybind11 or similar.

- A `track_cache` is introduced and passed on to `get_muongun_track`. This allows to avoid repeated calculation of `MuonGun.Track.harvest`. This parameter has been propagated through to all functions utilizing this method under the hood.

This PR thus also solves issue #15.