### PR TITLE
Update dependency ShowerParameters

### DIFF
--- a/ic3_labels/labels/utils/cascade.py
+++ b/ic3_labels/labels/utils/cascade.py
@@ -13,9 +13,14 @@ try:
     ShowerParameters = I3SimConstants.ShowerParameters
 
 except (ImportError, AttributeError) as e:
-    print("Can not include 'ShowerParameters' from icecube.sim_services")
-    print('Using custom python module instead.')
-    from ic3_labels.labels.utils.shower_parameters import ShowerParameters
+
+    try:
+        from icecube.sim_services import ShowerParameters
+        ShowerParameters = ShowerParameters
+    except ImportError:
+        print("Can not include 'ShowerParameters' from icecube.sim_services")
+        print('Using custom python module instead.')
+        from ic3_labels.labels.utils.shower_parameters import ShowerParameters
 
 from ic3_labels.labels.utils import geometry
 from ic3_labels.labels.utils.neutrino import get_interaction_neutrino

--- a/ic3_labels/labels/utils/cascade.py
+++ b/ic3_labels/labels/utils/cascade.py
@@ -13,7 +13,6 @@ try:
     ShowerParameters = I3SimConstants.ShowerParameters
 
 except (ImportError, AttributeError) as e:
-
     try:
         from icecube.sim_services import ShowerParameters
         ShowerParameters = ShowerParameters


### PR DESCRIPTION
It seems that `icecube.sim_services.I3SimConstants.ShowerParameters` was moved to `icecube.sim_services.ShowerParameters`

This change makes no difference if the _local_ `ShowerParameters` is equivalent to the one in `icecube.sim_services`, however if the parameters are at some point changed in `icecube.sim_services`, these changes will now automatically be reflected in this repository. 