### PR TITLE
Extend base module

### DIFF
--- a/ic3_labels/labels/base_module.py
+++ b/ic3_labels/labels/base_module.py
@@ -34,12 +34,47 @@ class MCLabelsBase(icetray.I3ConditionalModule):
         self.AddParameter("OutputKey", "Save labels to this frame key.",
                           'LabelsDeepLearning')
 
+        self.AddParameter("RunOnDAQFrames",
+                    "If True, the label module will run on DAQ frames "
+                    "instead of Physics frames",
+                    False)
+
     def Configure(self):
         self._pulse_map_string = self.GetParameter("PulseMapString")
         self._mcpe_series_map_name = self.GetParameter("MCPESeriesMapName")
         self._primary_key = self.GetParameter("PrimaryKey")
         self._convex_hull = self.GetParameter("ConvexHull")
         self._output_key = self.GetParameter("OutputKey")
+        self._run_on_daq = self.GetParameter("RunOnDAQFrames")
+
+    def DAQ(self, frame):
+        """Run on DAQ frames.
+
+        Parameters
+        ----------
+        frame : I3Frame
+            The current DAQ Frame
+        """
+        if self._run_on_daq:
+            self.add_labels(frame)
+
+        self.PushFrame(frame)
+
+    def Physics(self, frame):
+        """Run on Physics frames.
+
+        Parameters
+        ----------
+        frame : I3Frame
+            The current Physics Frame
+        """
+        if not self._run_on_daq:
+            self.add_labels(frame)
+
+        self.PushFrame(frame)
+
+    def add_labels(self, frame):
+        raise NotImplementedError
 
     def Geometry(self, frame):
         geoMap = frame['I3Geometry'].omgeo

--- a/ic3_labels/labels/base_module.py
+++ b/ic3_labels/labels/base_module.py
@@ -74,6 +74,17 @@ class MCLabelsBase(icetray.I3ConditionalModule):
         self.PushFrame(frame)
 
     def add_labels(self, frame):
+        """Add labels to frame
+
+        This method should be implemented by the derived class.
+        Labels should be added to the frame using the key specified in
+        self._output_key.
+
+        Parameters
+        ----------
+        frame : I3Frame
+            The frame to which to add the labels.
+        """
         raise NotImplementedError
 
     def Geometry(self, frame):

--- a/ic3_labels/labels/modules/event_generator/multi_cascade_labels.py
+++ b/ic3_labels/labels/modules/event_generator/multi_cascade_labels.py
@@ -26,43 +26,12 @@ class EventGeneratorMultiCascadeLabels(MCLabelsBase):
                           "Extend boundary of convex hull around IceCube "
                           "[in meters].",
                           500)
-        self.AddParameter("RunOnDAQFrames",
-                          "If True, the label module will run on DAQ frames "
-                          "instead of Physics frames",
-                          False)
 
     def Configure(self):
         # super(EventGeneratorMuonTrackLabels, self).Configure(self)
         MCLabelsBase.Configure(self)
         self._extend_boundary = self.GetParameter("ExtendBoundary")
         self._mc_tree_name = self.GetParameter("MCTreeName")
-        self._run_on_daq = self.GetParameter("RunOnDAQFrames")
-
-    def DAQ(self, frame):
-        """Run on DAQ frames.
-
-        Parameters
-        ----------
-        frame : I3Frame
-            The current DAQ Frame
-        """
-        if self._run_on_daq:
-            self.add_labels(frame)
-
-        self.PushFrame(frame)
-
-    def Physics(self, frame):
-        """Run on Physics frames.
-
-        Parameters
-        ----------
-        frame : I3Frame
-            The current Physics Frame
-        """
-        if not self._run_on_daq:
-            self.add_labels(frame)
-
-        self.PushFrame(frame)
 
     def add_labels(self, frame):
         """Add labels to frame

--- a/ic3_labels/labels/modules/event_generator/multi_cascade_labels.py
+++ b/ic3_labels/labels/modules/event_generator/multi_cascade_labels.py
@@ -4,6 +4,7 @@ from icecube import dataclasses, icetray
 from ic3_labels.labels.base_module import MCLabelsBase
 from ic3_labels.labels.utils import high_level as hl
 from ic3_labels.labels.utils.cascade import get_cascade_em_equivalent
+from ic3_labels.labels.utils import muon as mu_utils
 
 
 class EventGeneratorMultiCascadeLabels(MCLabelsBase):

--- a/ic3_labels/labels/modules/event_generator/muon_track_labels.py
+++ b/ic3_labels/labels/modules/event_generator/muon_track_labels.py
@@ -37,10 +37,6 @@ class EventGeneratorMuonTrackLabels(MCLabelsBase):
         self.AddParameter("NumQuantiles",
                           "Number of track energy quantiles to compute.",
                           20)
-        self.AddParameter("RunOnDAQFrames",
-                          "If True, the label module will run on DAQ frames "
-                          "instead of Physics frames",
-                          False)
 
     def Configure(self):
         # super(EventGeneratorMuonTrackLabels, self).Configure(self)
@@ -49,39 +45,12 @@ class EventGeneratorMuonTrackLabels(MCLabelsBase):
         self._correct_for_em_loss = self.GetParameter("UseEMEquivalenEnergy")
         self._num_cascades = self.GetParameter("NumCascades")
         self._num_quantiles = self.GetParameter("NumQuantiles")
-        self._run_on_daq = self.GetParameter("RunOnDAQFrames")
 
         if self._num_quantiles > 1000:
             raise ValueError('Only quantiles up to 1000 supported!')
 
         self._quantiles = np.linspace(
             1./self._num_quantiles, 1, self._num_quantiles)
-
-    def DAQ(self, frame):
-        """Run on DAQ frames.
-
-        Parameters
-        ----------
-        frame : I3Frame
-            The current DAQ Frame
-        """
-        if self._run_on_daq:
-            self.add_labels(frame)
-
-        self.PushFrame(frame)
-
-    def Physics(self, frame):
-        """Run on Physics frames.
-
-        Parameters
-        ----------
-        frame : I3Frame
-            The current Physics Frame
-        """
-        if not self._run_on_daq:
-            self.add_labels(frame)
-
-        self.PushFrame(frame)
 
     def add_labels(self, frame):
         """Add labels to frame

--- a/ic3_labels/labels/modules/modules.py
+++ b/ic3_labels/labels/modules/modules.py
@@ -29,7 +29,7 @@ class MCLabelsDeepLearning(MCLabelsBase):
         MCLabelsBase.Configure(self)
         self._is_muongun = self.GetParameter("IsMuonGun")
 
-    def Physics(self, frame):
+    def add_labels(self, frame):
         # get track_cache
         track_cache, _ = mu_utils.get_muongun_track_cache(frame)
 
@@ -47,11 +47,9 @@ class MCLabelsDeepLearning(MCLabelsBase):
         # write to frame
         frame.Put(self._output_key, labels)
 
-        self.PushFrame(frame)
-
 
 class MCLabelsTau(MCLabelsBase):
-    def Physics(self, frame):
+    def add_labels(self, frame):
         # get track_cache
         track_cache, _ = mu_utils.get_muongun_track_cache(frame)
 
@@ -63,8 +61,6 @@ class MCLabelsTau(MCLabelsBase):
 
         # write to frame
         frame.Put(self._output_key, labels)
-
-        self.PushFrame(frame)
 
 
 class MCLabelsCascadeParameters(MCLabelsBase):
@@ -99,7 +95,7 @@ class MCLabelsCascades(MCLabelsBase):
         MCLabelsBase.Configure(self)
         self._extend_boundary = self.GetParameter("ExtendBoundary")
 
-    def Physics(self, frame):
+    def add_labels(self, frame):
 
         # get track_cache
         track_cache, _ = mu_utils.get_muongun_track_cache(frame)
@@ -115,11 +111,9 @@ class MCLabelsCascades(MCLabelsBase):
         # write to frame
         frame.Put(self._output_key, labels)
 
-        self.PushFrame(frame)
-
 
 class MCLabelsCorsikaMultiplicity(MCLabelsBase):
-    def Physics(self, frame):
+    def add_labels(self, frame):
 
         # get track_cache
         track_cache, _ = mu_utils.get_muongun_track_cache(frame)
@@ -157,11 +151,9 @@ class MCLabelsCorsikaMultiplicity(MCLabelsBase):
         # write to frame
         frame.Put(self._output_key, dataclasses.I3MapStringDouble(labels))
 
-        self.PushFrame(frame)
-
 
 class MCLabelsCorsikaAzimuthExcess(MCLabelsBase):
-    def Physics(self, frame):
+    def add_labels(self, frame):
 
         # get track_cache
         track_cache, _ = mu_utils.get_muongun_track_cache(frame)
@@ -198,8 +190,6 @@ class MCLabelsCorsikaAzimuthExcess(MCLabelsBase):
 
         # write to frame
         frame.Put(self._output_key, labels)
-
-        self.PushFrame(frame)
 
 
 class MCLabelsMuonScattering(MCLabelsBase):
@@ -244,7 +234,7 @@ class MCLabelsMuonScattering(MCLabelsBase):
         self._min_muon_entry_energy = self.GetParameter("MinMuonEntryEnergy")
         self._min_rel_loss_energy = self.GetParameter("MinRelativeLossEnergy")
 
-    def Physics(self, frame):
+    def add_labels(self, frame):
 
         # get track_cache
         track_cache, _ = mu_utils.get_muongun_track_cache(frame)
@@ -261,8 +251,6 @@ class MCLabelsMuonScattering(MCLabelsBase):
                             track_cache=track_cache,
                             )
         frame.Put(self._output_key, labels)
-
-        self.PushFrame(frame)
 
 
 class MCLabelsMuonEnergyLosses(MCLabelsBase):
@@ -290,7 +278,7 @@ class MCLabelsMuonEnergyLosses(MCLabelsBase):
         self._include_under_over_flow = \
             self.GetParameter("IncludeUnderOverFlow")
 
-    def Physics(self, frame):
+    def add_labels(self, frame):
 
         labels = dataclasses.I3MapStringDouble()
 
@@ -326,8 +314,6 @@ class MCLabelsMuonEnergyLosses(MCLabelsBase):
 
         frame.Put(self._output_key, labels)
 
-        self.PushFrame(frame)
-
 
 class MCLabelsMuonEnergyLossesInCylinder(MCLabelsBase):
     def __init__(self, context):
@@ -348,7 +334,7 @@ class MCLabelsMuonEnergyLossesInCylinder(MCLabelsBase):
         self._cylinder_height = self.GetParameter("CylinderHeight")
         self._cylinder_radius = self.GetParameter("CylinderRadius")
 
-    def Physics(self, frame):
+    def add_labels(self, frame):
 
         # get track_cache
         track_cache, _ = mu_utils.get_muongun_track_cache(frame)
@@ -386,8 +372,6 @@ class MCLabelsMuonEnergyLossesInCylinder(MCLabelsBase):
 
         frame.Put(self._output_key, labels)
 
-        self.PushFrame(frame)
-
 
 class MCLabelsMuonEnergyLossesMillipede(MCLabelsBase):
     def __init__(self, context):
@@ -418,7 +402,7 @@ class MCLabelsMuonEnergyLossesMillipede(MCLabelsBase):
         self._write_vector = self.GetParameter("WriteParticleVector")
         self._max_num_bins = self.GetParameter("MaxNumBins")
 
-    def Physics(self, frame):
+    def add_labels(self, frame):
 
         # get track_cache
         track_cache, _ = mu_utils.get_muongun_track_cache(frame)
@@ -493,5 +477,3 @@ class MCLabelsMuonEnergyLossesMillipede(MCLabelsBase):
                 )
                 part_vec.append(part)
             frame.Put(self._output_key + 'ParticleVector', part_vec)
-
-        self.PushFrame(frame)

--- a/ic3_labels/labels/modules/modules.py
+++ b/ic3_labels/labels/modules/modules.py
@@ -68,7 +68,8 @@ class MCLabelsTau(MCLabelsBase):
 
 
 class MCLabelsCascadeParameters(MCLabelsBase):
-    def Physics(self, frame):
+
+    def add_labels(self, frame):
         # get track_cache
         track_cache, _ = mu_utils.get_muongun_track_cache(frame)
 
@@ -82,8 +83,6 @@ class MCLabelsCascadeParameters(MCLabelsBase):
 
         # write to frame
         frame.Put(self._output_key, labels)
-
-        self.PushFrame(frame)
 
 
 class MCLabelsCascades(MCLabelsBase):


### PR DESCRIPTION
Have to admit that I did not extensively tested it yet (can do that soon). But if I understand everything correctly should this PR not change any default behaviour of the existing module. Per default default they will not do anything on a Q frame and they will use their own implementation of the `Physics` function. Only if one module had only implemented the `DAQ` function this PR would break things. I change one Module to use the `add_labels` function.