### PR TITLE
Remove trailing comma

### DIFF
--- a/ic3_labels/labels/base_module.py
+++ b/ic3_labels/labels/base_module.py
@@ -2,7 +2,6 @@
 """
 
 from __future__ import print_function, division
-import numpy as np
 from icecube import dataclasses, icetray, phys_services
 
 from ic3_labels.labels.utils import detector

--- a/ic3_labels/labels/utils/neutrino.py
+++ b/ic3_labels/labels/utils/neutrino.py
@@ -2,7 +2,6 @@
 """
 
 from __future__ import print_function, division
-import numpy as np
 from icecube import dataclasses, MuonGun, simclasses
 from icecube.phys_services import I3Calculator
 

--- a/ic3_labels/weights/mceq_models.py
+++ b/ic3_labels/weights/mceq_models.py
@@ -374,7 +374,7 @@ def get_spline(
                 interaction_model=interaction_model,
                 primary_model=pmodel,
                 theta_deg=0.0,
-                **config_updates,
+                **config_updates
             )
             e_grid = np.log10(deepcopy(mceq_run.e_grid))
             spline_dicts, flux_dicts = __solve_month__(
@@ -475,7 +475,7 @@ class MCEQFlux(object):
         season="full_year",
         flux_type="total",
         random_state=None,
-        **kwargs,
+        **kwargs
     ):
         """Initialize MCEQFlux Instance
 

--- a/ic3_labels/weights/nuveto_models.py
+++ b/ic3_labels/weights/nuveto_models.py
@@ -621,7 +621,7 @@ class AtmosphericNuVeto(object):
         season="full_year",
         flux_type="total",
         random_state=None,
-        **kwargs,
+        **kwargs
     ):
         """Initialize AtmosphericNuVeto Instance
 

--- a/ic3_labels/weights/resources/cache_simprod_data.py
+++ b/ic3_labels/weights/resources/cache_simprod_data.py
@@ -290,7 +290,7 @@ def get_generator_settings(
             * I3Units.deg,
             ZenithMax=get_steering_param("NUGEN::zenithmax", type=float)
             * I3Units.deg,
-            **nugen_kwargs,
+            **nugen_kwargs
         )
 
     elif category == "CORSIKA-in-ice":

--- a/ic3_labels/weights/segments.py
+++ b/ic3_labels/weights/segments.py
@@ -454,7 +454,7 @@ def WeightEvents(
             AddMCEqWeights,
             "AddMCEqWeights",
             n_files=dataset_n_files,
-            **mceq_kwargs,
+            **mceq_kwargs
         )
 
     if add_nuveto_pf and dataset_type in ["nugen"]:
@@ -463,7 +463,7 @@ def WeightEvents(
         tray.AddModule(
             AddNuVetoPassingFraction,
             "AddNuVetoPassingFraction",
-            **nuveto_kwargs,
+            **nuveto_kwargs
         )
 
     if add_mese_weights and dataset_type in ["muongun", "nugen", "genie"]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=44.0"]  # Note: unfortunately need python >=2.7
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -13,7 +13,7 @@ authors = [
 maintainers = [
     { name = "Mirco Huennefeld", email = "mirco.huennefeld@tu-dortmund.de" },
 ]
-requires-python = ">=3.7"
+requires-python = ">=2.7"  # Note: unfortunately need python >=2.7
 
 dependencies = [
     'numpy', 'click', 'pyyaml', 'scipy', 'MCEq', 'crflux',
@@ -51,7 +51,10 @@ version = {attr = "ic3_labels.__version__"}
 
 [tool.black]
 line-length = 79
-target-version = ["py38"]
+# technically, black does not support python2.
+# This is all python versions black knows of and gets
+# rid of the trailing comma bug
+target-version = ["py33", "py34", "py35", "py36", "py37", "py38", "py39", "py310", "py311"]
 
 [tool.ruff]
 # select = ["ALL"]
@@ -68,6 +71,7 @@ lint.ignore = [
     "T20",    # flake8-print
     "TCH",    # flake8-type-checking
     "S101",   # assert-used
+    "COM812", # trailing comma to not insert after **kwargs, which is a syntax error prior to py3.6
     "F401",   # imported but unused. NOTE: sooner or later, we should not ignore this
     ]
 line-length = 79


### PR DESCRIPTION
There are cases, when one may want to utilize this repository for older simulation sets that may require python 2. While we don't want to go to great lengths to keep Python2 support, we shouldn't deliberately break it either. This PR removes the trailing commata after kwargs arguments that were introduced in the pre-commits (#25). The config has been updated to ignore these and to also support older python versions.