### PR TITLE
Fix looping over omgeo maps

### DIFF
--- a/ic3_labels/labels/base_module.py
+++ b/ic3_labels/labels/base_module.py
@@ -51,7 +51,6 @@ class MCLabelsBase(icetray.I3ConditionalModule):
         self._convex_hull = self.GetParameter("ConvexHull")
         self._output_key = self.GetParameter("OutputKey")
         self._run_on_daq = self.GetParameter("RunOnDAQFrames")
-        print(self._mcpe_series_map_name)
 
     def DAQ(self, frame):
         """Run on DAQ frames.

--- a/ic3_labels/labels/base_module.py
+++ b/ic3_labels/labels/base_module.py
@@ -51,6 +51,7 @@ class MCLabelsBase(icetray.I3ConditionalModule):
         self._convex_hull = self.GetParameter("ConvexHull")
         self._output_key = self.GetParameter("OutputKey")
         self._run_on_daq = self.GetParameter("RunOnDAQFrames")
+        print(self._mcpe_series_map_name)
 
     def DAQ(self, frame):
         """Run on DAQ frames.
@@ -94,14 +95,15 @@ class MCLabelsBase(icetray.I3ConditionalModule):
 
     def Geometry(self, frame):
         geoMap = frame["I3Geometry"].omgeo
+
         domPosDict = {
-            (i[0][0], i[0][1]): (
-                i[1].position.x,
-                i[1].position.y,
-                i[1].position.z,
+            (omkey[0], omkey[1]): (
+                om.position.x,
+                om.position.y,
+                om.position.z,
             )
-            for i in geoMap
-            if i[1].omtype.name == "IceCube"
+            for omkey, om in geoMap.items()
+            if om.omtype.name == "IceCube"
         }
 
         if self._convex_hull is None:

--- a/ic3_labels/weights/mese_weights.py
+++ b/ic3_labels/weights/mese_weights.py
@@ -150,14 +150,15 @@ class MESEWeights(icetray.I3ConditionalModule):
 
     def Geometry(self, frame):
         geoMap = frame["I3Geometry"].omgeo
+
         domPosDict = {
-            (i[0][0], i[0][1]): (
-                i[1].position.x,
-                i[1].position.y,
-                i[1].position.z,
+            (omkey[0], omkey[1]): (
+                om.position.x,
+                om.position.y,
+                om.position.z,
             )
-            for i in geoMap
-            if i[1].omtype.name == "IceCube"
+            for omkey, om in geoMap.items()
+            if om.omtype.name == "IceCube"
         }
         points = [
             domPosDict[(31, 1)],

--- a/ic3_labels/weights/self_veto.py
+++ b/ic3_labels/weights/self_veto.py
@@ -63,14 +63,15 @@ class AtmosphericSelfVetoModule(icetray.I3ConditionalModule):
 
     def Geometry(self, frame):
         geoMap = frame["I3Geometry"].omgeo
+
         domPosDict = {
-            (i[0][0], i[0][1]): (
-                i[1].position.x,
-                i[1].position.y,
-                i[1].position.z,
+            (omkey[0], omkey[1]): (
+                om.position.x,
+                om.position.y,
+                om.position.z,
             )
-            for i in geoMap
-            if i[1].omtype.name == "IceCube"
+            for omkey, om in geoMap.items()
+            if om.omtype.name == "IceCube"
         }
         points = [
             domPosDict[(31, 1)],


### PR DESCRIPTION
In icetray v1.13.0, an old method of accessing maps was removed, which affects looping over the om geometries.

This PR just changes some loops over `frame["I3Geometry"].omgeo` since they used the removed method and no longer work with the latest version of icetray.