### PR TITLE
Sphere inf track labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,7 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# cache files
+mceq.cache
+nuveto.cache

--- a/.gitignore
+++ b/.gitignore
@@ -105,4 +105,4 @@ venv.bak/
 
 # cache files
 mceq.cache
-nuveto.cache
+nuVeto.cache

--- a/ic3_labels/labels/base_module.py
+++ b/ic3_labels/labels/base_module.py
@@ -135,6 +135,16 @@ class MCLabelsBase(icetray.I3ConditionalModule):
                     detector.icecube_hull_points_i3,
                     padding=extension,
                 )
+
+            elif self._convex_hull.startswith("sphere_r"):
+                radius = float(self._convex_hull.split("_r")[-1])
+
+                # Note: Sphere.intersection method is broken in older
+                # icetray versions. Use the following instead:
+                from ic3_labels.labels.utils.geometry_scipy import Sphere
+
+                self._convex_hull = Sphere(radius)
+                # self._convex_hull = phys_services.Sphere(0.0, radius)
             else:
                 self._convex_hull = getattr(detector, self._convex_hull)
 

--- a/ic3_labels/labels/modules/event_generator/muon_track_labels.py
+++ b/ic3_labels/labels/modules/event_generator/muon_track_labels.py
@@ -126,6 +126,7 @@ class EventGeneratorSphereInfTrackLabels(MCLabelsBase):
         self._sphere_radius = self.GetParameter("SphereRadius")
         self._bin_width = self.GetParameter("EnergyLossBinWidth")
         self._sphere_convex_hull = Sphere(radius=self._sphere_radius)
+        self._max_bins = (2 * self._sphere_radius) // self._bin_width
 
     def add_labels(self, frame):
         """Add labels to frame
@@ -174,8 +175,11 @@ class EventGeneratorSphereInfTrackLabels(MCLabelsBase):
                 compute_em_equivalent=True,
                 include_under_over_flow=False,
             )
-            for i, energy_loss in enumerate(energy_losses):
-                labels["energy_loss_{:04d}".format(i)] = energy_loss
+            for i in range(self._max_bins):
+                if i >= len(energy_losses):
+                    labels[f"energy_loss_{i:04d}"] = 0.0
+                else:
+                    labels[f"energy_loss_{i:04d}"] = energy_losses[i]
         # -----------------
 
         # gather labels

--- a/ic3_labels/labels/modules/event_generator/muon_track_labels.py
+++ b/ic3_labels/labels/modules/event_generator/muon_track_labels.py
@@ -1,13 +1,105 @@
 import numpy as np
-from icecube import dataclasses, icetray
+from icecube import dataclasses
 
 from ic3_labels.labels.base_module import MCLabelsBase
 from ic3_labels.labels.utils import high_level as hl
 from ic3_labels.labels.utils import muon as mu_utils
+from ic3_labels.labels.utils import geometry as geo_utils
 from ic3_labels.labels.modules.event_generator.utils import (
     get_track_energy_depositions,
     compute_stochasticity,
+    get_muon_from_frame,
 )
+
+
+class EventGeneratorSphereInfTrackLabels(MCLabelsBase):
+    """Generate labels for tracks in the sphere
+
+    The labels contain information of the track such as:
+
+        - information at the entry point of the infinite
+          track in the sphere: (x, y, z, theta, phi, E, t)
+        - information at the exit point of the infinite
+          track in the sphere: (x, y, z, theta, phi, E, t)
+        - Direction of the track (theta, phi)
+
+    """
+
+    def __init__(self, context):
+        MCLabelsBase.__init__(self, context)
+        self.AddParameter(
+            "SphereRadius",
+            "The radius of the sphere around IceCube [in meters].",
+            600,
+        )
+
+    def Configure(self):
+        MCLabelsBase.Configure(self)
+        self._sphere_radius = self.GetParameter("SphereRadius")
+
+    def add_labels(self, frame):
+        """Add labels to frame
+
+        Parameters
+        ----------
+        frame : I3Frame
+            The frame to which to add the labels.
+        """
+        # get track_cache
+        track_cache, _ = mu_utils.get_muongun_track_cache(frame)
+
+        # get muon
+        muon = get_muon_from_frame(frame, primary=frame[self._primary_key])
+
+        # get intersectios with sphere
+        dist_entry, dist_exit = geo_utils.get_sphere_intersection(
+            radius=self._sphere_radius,
+            anchor=muon.pos,
+            direction=muon.dir,
+        )
+
+        entry_pos = muon.pos + dist_entry * muon.dir
+        exit_pos = muon.pos + dist_exit * muon.dir
+
+        # compute angle representation
+        entry_dir = dataclasses.I3Direction(-entry_pos)
+        exit_dir = dataclasses.I3Direction(-exit_pos)
+
+        # get energy at entry and exit point
+        entry_energy = mu_utils.get_muon_energy_at_distance(
+            frame=frame,
+            muon=muon,
+            distance=dist_entry,
+            track_cache=track_cache,
+        )
+        exit_energy = mu_utils.get_muon_energy_at_distance(
+            frame=frame,
+            muon=muon,
+            distance=dist_exit,
+            track_cache=track_cache,
+        )
+
+        # gather labels
+        labels = dataclasses.I3MapStringDouble()
+        labels["entry_x"] = entry_pos.x
+        labels["entry_y"] = entry_pos.y
+        labels["entry_z"] = entry_pos.z
+        labels["entry_t"] = muon.time + dist_entry / muon.speed
+        labels["entry_zenith"] = entry_dir.zenith
+        labels["entry_azimuth"] = entry_dir.azimuth
+        labels["entry_energy"] = entry_energy
+        labels["exit_x"] = exit_pos.x
+        labels["exit_y"] = exit_pos.y
+        labels["exit_z"] = exit_pos.z
+        labels["exit_t"] = muon.time + dist_exit / muon.speed
+        labels["exit_zenith"] = exit_dir.zenith
+        labels["exit_azimuth"] = exit_dir.azimuth
+        labels["exit_energy"] = exit_energy
+        labels["zenith"] = muon.dir.zenith
+        labels["azimuth"] = muon.dir.azimuth
+
+        # write to frame
+        frame.Put(self._output_key, labels)
 
 
 class EventGeneratorMuonTrackLabels(MCLabelsBase):
@@ -64,7 +156,7 @@ class EventGeneratorMuonTrackLabels(MCLabelsBase):
             The frame to which to add the labels.
         """
         # get muon
-        muon = self.get_muon(frame, primary=frame[self._primary_key])
+        muon = get_muon_from_frame(frame, primary=frame[self._primary_key])
 
         # compute energy updates and high energy losses
         energy_depositions_dict = get_track_energy_depositions(
@@ -172,70 +264,3 @@ class EventGeneratorMuonTrackLabels(MCLabelsBase):
 
         # write to frame
         frame.Put(self._output_key, labels)
-
-    def get_muon(self, frame, primary):
-        """Get muon from frame
-
-        Parameters
-        ----------
-        frame : I3Frame
-            The current frame.
-        primary : I3Particle
-            The primary particle.
-
-        Returns
-        -------
-        I3Particle
-            The muon from the frame
-
-        Raises
-        ------
-        ValueError
-            If not muon is found.
-        """
-
-        # NuGen Dataset
-        if primary.is_neutrino:
-            muon = mu_utils.get_muon_of_inice_neutrino(frame)
-
-            if muon is None:
-                print(frame["I3MCTree"])
-                raise ValueError("Did not find a muon!")
-
-        # MuonGun Dataset
-        elif (
-            primary.type_string == "unknown" and primary.pdg_encoding == 0
-        ) or mu_utils.is_muon(primary):
-
-            if mu_utils.is_muon(primary):
-                muon = primary
-
-                # -----------------------------
-                # muon primary: MuonGun dataset
-                # -----------------------------
-                daugters = frame["I3MCTree"].get_daughters(muon)
-                if len(daugters) == 1:
-                    daughter = daugters[0]
-                    if mu_utils.is_muon(daughter) and (
-                        (daughter.id == primary.id)
-                        and (daughter.dir == primary.dir)
-                        and (daughter.pos == primary.pos)
-                        and (daughter.energy == primary.energy)
-                    ):
-                        muon = daughter
-
-            else:
-                daughters = frame["I3MCTree"].get_daughters(primary)
-                muon = daughters[0]
-
-                # Perform some safety checks to make sure that this is MuonGun
-                assert (
-                    len(daughters) == 1
-                ), "Expected 1 daughter for MuonGun, but got {!r}".format(
-                    daughters
-                )
-                assert mu_utils.is_muon(
-                    muon
-                ), "Expected muon but got {!r}".format(muon)
-
-        return muon

--- a/ic3_labels/labels/modules/event_generator/muon_track_labels.py
+++ b/ic3_labels/labels/modules/event_generator/muon_track_labels.py
@@ -30,7 +30,7 @@ class EventGeneratorSphereInfTrackLabels(MCLabelsBase):
         self.AddParameter(
             "SphereRadius",
             "The radius of the sphere around IceCube [in meters].",
-            600,
+            750,
         )
 
     def Configure(self):

--- a/ic3_labels/labels/utils/geometry.py
+++ b/ic3_labels/labels/utils/geometry.py
@@ -17,6 +17,7 @@ from ic3_labels.labels.utils.geometry_scipy import (
     distance_to_axis_aligned_Volume,
     distance_to_icecube_hull,
     distance_to_deepcore_hull,
+    get_sphere_intersection,
 )
 
 

--- a/ic3_labels/labels/utils/geometry_scipy.py
+++ b/ic3_labels/labels/utils/geometry_scipy.py
@@ -45,6 +45,12 @@ def get_sphere_intersection(radius, anchor, direction):
     return dist_entry, dist_exit
 
 
+class Pair:
+    def __init__(self, first, second):
+        self.first = first
+        self.second = second
+
+
 class Sphere:
     """Wrapper class for sphere as a convex hull"""
 
@@ -52,11 +58,14 @@ class Sphere:
         self.radius = radius
 
     def intersection(self, pos, direction):
-        return get_sphere_intersection(
+        result = get_sphere_intersection(
             radius=self.radius,
             anchor=pos,
             direction=direction,
         )
+        if result is None:
+            return Pair(np.nan, np.nan)
+        return Pair(*result)
 
 
 def ray_triangle_intersection(ray_near, ray_dir, triangle):

--- a/ic3_labels/labels/utils/geometry_scipy.py
+++ b/ic3_labels/labels/utils/geometry_scipy.py
@@ -6,6 +6,45 @@ import numpy as np
 import logging
 
 
+def get_sphere_intersection(radius, anchor, direction):
+    """Get intersections with sphere
+
+    Get intersection distances of an infinite
+    track with sphere around detector center (0, 0, 0).
+
+    Parameters
+    ----------
+    radius : float
+        Radius of sphere [in meters].
+    anchor : I3Position
+        Anchor point of track.
+    direction : I3Direction
+        Direction of track.
+
+    Returns
+    -------
+    tuple or None
+        The distance to the entry and exit point of the track with the
+        sphere around the detector center if the track intersects the
+        sphere. Otherwise None.
+    """
+    p = (
+        direction.x * anchor.x
+        + direction.y * anchor.y
+        + direction.z * anchor.z
+    )
+    term_inside_root = p**2 - (anchor.magnitude**2 - radius**2)
+
+    if term_inside_root < 0:
+        return None
+
+    sqrt_term = np.sqrt(term_inside_root)
+
+    dist_entry = -p - sqrt_term
+    dist_exit = -p + sqrt_term
+    return dist_entry, dist_exit
+
+
 def ray_triangle_intersection(ray_near, ray_dir, triangle):
     """
     Möller–Trumbore intersection algorithm in pure python

--- a/ic3_labels/labels/utils/geometry_scipy.py
+++ b/ic3_labels/labels/utils/geometry_scipy.py
@@ -45,6 +45,20 @@ def get_sphere_intersection(radius, anchor, direction):
     return dist_entry, dist_exit
 
 
+class Sphere:
+    """Wrapper class for sphere as a convex hull"""
+
+    def __init__(self, radius):
+        self.radius = radius
+
+    def intersection(self, pos, direction):
+        return get_sphere_intersection(
+            radius=self.radius,
+            anchor=pos,
+            direction=direction,
+        )
+
+
 def ray_triangle_intersection(ray_near, ray_dir, triangle):
     """
     Möller–Trumbore intersection algorithm in pure python

--- a/ic3_labels/labels/utils/high_level.py
+++ b/ic3_labels/labels/utils/high_level.py
@@ -1431,6 +1431,17 @@ def get_cascade_parameters(
                 extend_boundary=float("inf"),
                 sanity_check=False,
             )
+            if cascade is None:
+                cascade = dataclasses.I3Particle()
+                cascade.pos.x = float("nan")
+                cascade.pos.y = float("nan")
+                cascade.pos.z = float("nan")
+                cascade.time = float("nan")
+                cascade.energy = float("nan")
+                cascade.length = float("nan")
+                cascade.dir = dataclasses.I3Direction(
+                    float("nan"), float("nan")
+                )
 
         else:
             # ------------------------------
@@ -1454,7 +1465,7 @@ def get_cascade_parameters(
             e_hadron = 0.0
             e_track = energy
 
-    if write_mc_cascade_to_frame:
+    if write_mc_cascade_to_frame and cascade is not None:
         frame["MCCascade"] = cascade
 
     labels["cascade_x"] = cascade.pos.x
@@ -1467,8 +1478,13 @@ def get_cascade_parameters(
     labels["cascade_max_extension"] = cascade.length
 
     # compute fraction of energy for each component: EM, hadronic, track
-    labels["energy_fraction_em"] = e_em / cascade.energy
-    labels["energy_fraction_hadron"] = e_hadron / cascade.energy
-    labels["energy_fraction_track"] = e_track / cascade.energy
+    if cascade.energy > 0:
+        labels["energy_fraction_em"] = e_em / cascade.energy
+        labels["energy_fraction_hadron"] = e_hadron / cascade.energy
+        labels["energy_fraction_track"] = e_track / cascade.energy
+    else:
+        labels["energy_fraction_em"] = float("nan")
+        labels["energy_fraction_hadron"] = float("nan")
+        labels["energy_fraction_track"] = float("nan")
 
     return labels

--- a/ic3_labels/labels/utils/high_level.py
+++ b/ic3_labels/labels/utils/high_level.py
@@ -1045,6 +1045,7 @@ def get_cascade_labels(
     labels["PrimaryDirectionZ"] = primary.dir.z
 
     # set pid variables to false per default
+    labels["p_neutrino"] = 0
     labels["p_starting"] = 0
     labels["p_starting_300m"] = 0
     labels["p_starting_glashow"] = 0
@@ -1067,6 +1068,7 @@ def get_cascade_labels(
         # --------------------
         # NuGen dataset
         # --------------------
+        labels["p_neutrino"] = 1
         mctree = frame[mctree_name]
         cascade = get_cascade_of_primary_nu(
             frame, primary, convex_hull=None, extend_boundary=extend_boundary

--- a/ic3_labels/labels/utils/muon.py
+++ b/ic3_labels/labels/utils/muon.py
@@ -593,7 +593,7 @@ def get_inf_muon_binned_energy_losses(
 
         # compute EM-equivalent energy of daughter
         if compute_em_equivalent:
-            energy = get_cascade_em_equivalent(frame["I3MCTree"], daughter)
+            energy = get_cascade_em_equivalent(frame["I3MCTree"], daughter)[0]
         else:
             energy = daughter.energy
 

--- a/ic3_labels/labels/utils/neutrino.py
+++ b/ic3_labels/labels/utils/neutrino.py
@@ -52,8 +52,9 @@ def get_interaction_neutrino(
     nu_in_ice = None
     for p in mctree:
         if p.is_neutrino and p.location_type_string == "InIce":
-            nu_in_ice = p
-            break
+            if mctree.is_in_subtree(primary.id, p.id):
+                nu_in_ice = p
+                break
 
     if nu_in_ice is not None:
 


### PR DESCRIPTION
Adds additional labels for EventGenerator training including `EventGeneratorSphereInfTrackLabels`. Option to use muon from primary in `MCLabelsMuonEnergyLosses`. Also fixes some further edge cases in `get_cascade_labels` and adds `p_neutrino` as and additional label.